### PR TITLE
Add preventPassThrough parameter to movement
      calculations

### DIFF
--- a/services/games_service.go
+++ b/services/games_service.go
@@ -241,7 +241,7 @@ func (s *BaseGamesService) GetOptionsAt(ctx context.Context, req *v1.GetOptionsA
 
 		// Get movement options if unit has movement left and move is allowed
 		if unit.AvailableHealth > 0 && unit.DistanceLeft > 0 && moveAllowed {
-			pathsResult, err := dmp.GetMovementOptions(rtGame, req.Q, req.R)
+			pathsResult, err := dmp.GetMovementOptions(rtGame, req.Q, req.R, false)
 			if err == nil {
 				allPaths = pathsResult
 

--- a/tests/action_progression_test.go
+++ b/tests/action_progression_test.go
@@ -162,7 +162,7 @@ func TestProgressionStepAdvancement(t *testing.T) {
 		ToR:   0,
 	}
 
-	err := mp.ProcessMoveUnit(game, &v1.GameMove{Player: 1}, moveAction)
+	err := mp.ProcessMoveUnit(game, &v1.GameMove{Player: 1}, moveAction, false)
 	if err != nil {
 		t.Fatalf("Failed to process move: %v", err)
 	}


### PR DESCRIPTION
## Summary
      Fixes #8

      Add a  parameter to movement calculations that controls whether units can traverse through occupied
      tiles.

      ## Changes
      - Add  parameter to , , , and
       functions
      - When  (default), units can traverse through occupied tiles but cannot land on them
      - When , units cannot traverse through occupied tiles (blocks movement entirely)
      - Update all call sites to pass the new parameter
      - Add  test to verify both behaviors

      ## Behavior
      With tiles A -> B -> C where B is occupied:
      - : Unit on A can reach C (passes through B but can't stop there)
      - : Unit on A cannot reach C (B blocks the path)

      ## Test Plan
      - [x] All existing movement tests pass
      - [x] New  test validates both pass-through and blocking behavior