### PR TITLE
Fix build options using hardcoded coins instead of actual player coins

### DIFF
--- a/cmd/cli/cmd/options.go
+++ b/cmd/cli/cmd/options.go
@@ -12,14 +12,24 @@ import (
 
 // optionsCmd represents the options command
 var optionsCmd = &cobra.Command{
-	Use:   "options <unit>",
-	Short: "Show available options for a unit",
-	Long: `Display available actions for a unit at the specified position.
-The position can be a unit ID (like A1, B2) or coordinates (like 3,4).
+	Use:   "options <position>",
+	Short: "Show available options for a unit or tile",
+	Long: `Display available actions for a unit or tile at the specified position.
+
+For units: Shows movement, attack, and other unit actions.
+For tiles: Shows build options (if the tile is a base/harbor owned by current player).
+
+Position formats:
+  A1, B2      Unit shortcut (PlayerLetter + UnitNumber)
+  3,4         Q,R coordinates
+  r4,5        Row,Col coordinates
+  t:A1        Force tile lookup (use for build options)
+  t:3,4       Force tile lookup by coordinates
 
 Examples:
   ww options A1        Show options for unit A1
   ww options 3,4       Show options for position 3,4
+  ww options t:A1      Show build options for tile A1
   ww options A1 --json Show options as JSON`,
 	Args: cobra.ExactArgs(1),
 	RunE: runOptions,

--- a/cmd/cli/cmd/output.go
+++ b/cmd/cli/cmd/output.go
@@ -89,6 +89,9 @@ func FormatOptions(pc *PresenterContext, position string) string {
 		sb.WriteString(fmt.Sprintf("Unit %s at %s:\n", position, coord.String()))
 		sb.WriteString(fmt.Sprintf("  Type: %d, HP: %d, Moves: %f\n\n",
 			unit.UnitType, unit.AvailableHealth, unit.DistanceLeft))
+	} else {
+		// No unit - show position for tile options
+		sb.WriteString(fmt.Sprintf("Tile %s:\n\n", position))
 	}
 
 	// Get options

--- a/services/games_service.go
+++ b/services/games_service.go
@@ -181,9 +181,14 @@ func (s *BaseGamesService) GetOptionsAt(ctx context.Context, req *v1.GetOptionsA
 			// Get terrain definition for tile-specific actions
 			terrainDef, err := rtGame.RulesEngine.GetTerrainData(tile.TileType)
 			if err == nil {
-				// Get current player's coins (default to 100 for now, will be from game config later)
-				// TODO: Get actual player coins from rtGame.Game.Config.Players[currentPlayer].Coins
-				playerCoins := int32(100)
+				// Get current player's coins
+				playerCoins := int32(0)
+				for _, player := range rtGame.Config.Players {
+					if player.PlayerId == rtGame.CurrentPlayer {
+						playerCoins = player.Coins
+						break
+					}
+				}
 
 				// Get allowed actions for this tile
 				tileActions := rtGame.RulesEngine.GetAllowedActionsForTile(tile, terrainDef, playerCoins)


### PR DESCRIPTION
## Summary
- Fixed GetOptionsAt using hardcoded `playerCoins := int32(100)` instead of reading actual player coins from game config
- Improved CLI `ww options` command to document `t:` prefix for tile options
- Added "Tile X:" header when displaying options for tiles without units

## Test plan
- [x] Run `ww options t:A1` on a game where player has >100 coins
- [x] Verify all affordable units are shown, not just those ≤100

Fixes #12