### PR TITLE
Add toggle mode for tiles and consolidate toggle behavior in Presenter

### DIFF
--- a/web/pages/WorldEditorPage/WorldEditorPresenter.ts
+++ b/web/pages/WorldEditorPage/WorldEditorPresenter.ts
@@ -450,6 +450,15 @@ export class WorldEditorPresenter implements IWorldEditorPresenter, EventSubscri
         if (!this.world) return;
 
         if (this.toolState.brushSize === 0) {
+            // Toggle behavior for single tile: if same terrain type and player, remove it
+            const existingTile = this.world.getTileAt(q, r);
+            if (existingTile &&
+                existingTile.tileType === this.toolState.selectedTerrain &&
+                existingTile.player === playerId) {
+                this.world.removeTileAt(q, r);
+                this.world.removeUnitAt(q, r);
+                return;
+            }
             this.world.setTileAt(q, r, this.toolState.selectedTerrain, playerId);
         } else {
             const tiles = this.getTilesForBrush(q, r);
@@ -463,6 +472,14 @@ export class WorldEditorPresenter implements IWorldEditorPresenter, EventSubscri
         if (!this.world) return;
 
         if (this.toolState.brushSize === 0) {
+            // Toggle behavior for single unit: if same unit type and player, remove it
+            const existingUnit = this.world.getUnitAt(q, r);
+            if (existingUnit &&
+                existingUnit.unitType === this.toolState.selectedUnit &&
+                existingUnit.player === this.toolState.selectedPlayer) {
+                this.world.removeUnitAt(q, r);
+                return;
+            }
             this.world.setUnitAt(q, r, this.toolState.selectedUnit, this.toolState.selectedPlayer);
         } else {
             const tiles = this.getTilesForBrush(q, r);

--- a/web/pages/common/World.ts
+++ b/web/pages/common/World.ts
@@ -365,16 +365,8 @@ export class World {
         if (!this.tileExistsAt(q, r)) {
             this.setTileAt(q, r, 1, 0); // Terrain type 1 = Grass, no player ownership
         }
-        
-        // Check if same unit type and player already exists - if so, remove it (toggle behavior)
-        const existingUnit = this.getUnitAt(q, r);
-        if (existingUnit && existingUnit.unitType === unitType && existingUnit.player === player) {
-            // Same unit type and player - remove the unit (toggle off)
-            this.removeUnitAt(q, r);
-            return;
-        }
-        
-        // Different unit type/player or no existing unit - place/replace the unit
+
+        // Place or replace the unit at this location
         const key = `${q},${r}`;
         const unit = WD.from(models.Unit,{ q, r, unitType, player });
         this.units[key] = unit;


### PR DESCRIPTION
## Summary
- Add toggle mode for tiles when brush size is 1 (single tile)
- Move unit toggle behavior from World.ts to Presenter for consistency
- Clicking on existing tile/unit with same type and player now removes it

## Changes
- **WorldEditorPresenter.ts**: Add toggle behavior for tiles in `paintTerrain()`
- **WorldEditorPresenter.ts**: Add toggle behavior for units in `placeUnit()`
- **World.ts**: Remove toggle logic from `setUnitAt()` (now handled by Presenter)

## Test plan
- [ ] Select terrain, brush size = 1, place tile, click same tile again - should remove it
- [ ] Select terrain, brush size > 1, place tiles, click again - should NOT toggle (only single tile mode)
- [ ] Select unit, brush size = 1, place unit, click same unit again - should remove it
- [ ] Select different terrain/unit type and click - should replace, not toggle

Fixes #2