### PR TITLE
Fix unit panel height clipping in World Editor

### DIFF
--- a/web/templates/panels/ToolsPanel.html
+++ b/web/templates/panels/ToolsPanel.html
@@ -259,7 +259,7 @@
         <!-- Unit Palette -->
         <div
           id="unit-palette"
-          class="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto"
+          class="grid grid-cols-3 gap-2"
         >
           {{ $unitIndex := 1 }} {{ range .UnitTypes }}
           <button


### PR DESCRIPTION
## Summary
Remove `max-h-64` constraint from unit palette that was limiting its height to 256px and causing clipping.

## Changes
- **ToolsPanel.html**: Remove `max-h-64 overflow-y-auto` from unit palette div

The parent container (`flex-1 overflow-y-auto`) already handles overflow scrolling, so the unit palette can now fill the available space.

## Test plan
- [x] Open World Editor, switch to Units tab
- [x] Verify all unit buttons are visible without being clipped
- [x] Verify scrolling works when panel is smaller than content

Fixes #28