### PR TITLE
Add 'ww new' command to create games from CLI

### DIFF
--- a/cmd/cli/cmd/delete.go
+++ b/cmd/cli/cmd/delete.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	v1 "github.com/turnforge/weewar/gen/go/weewar/v1/models"
+	"github.com/turnforge/weewar/services/connectclient"
+)
+
+// deleteCmd represents the delete command
+var deleteCmd = &cobra.Command{
+	Use:   "delete <game_id>",
+	Short: "Delete a game",
+	Long: `Delete an existing game by its ID.
+Requires WEEWAR_SERVER to be set.
+
+Examples:
+  ww delete abc123                    Delete game abc123
+  ww delete abc123 --confirm=false    Delete without confirmation prompt`,
+	Args: cobra.ExactArgs(1),
+	RunE: runDelete,
+}
+
+func init() {
+	rootCmd.AddCommand(deleteCmd)
+}
+
+func runDelete(cmd *cobra.Command, args []string) error {
+	gameID := args[0]
+	ctx := context.Background()
+
+	serverURL := getServerURL()
+	if serverURL == "" {
+		return fmt.Errorf("WEEWAR_SERVER is required for deleting games (e.g., http://localhost:9080)")
+	}
+
+	// Confirmation prompt (unless disabled with --confirm=false)
+	if shouldConfirm() {
+		fmt.Printf("Are you sure you want to delete game %s? (y/n): ", gameID)
+		var response string
+		fmt.Scanln(&response)
+		if strings.ToLower(strings.TrimSpace(response)) != "y" {
+			return fmt.Errorf("delete cancelled")
+		}
+	}
+
+	// Create Connect client
+	gamesClient := connectclient.NewConnectGamesClient(serverURL)
+
+	if isVerbose() {
+		fmt.Printf("[VERBOSE] Using server: %s\n", serverURL)
+		fmt.Printf("[VERBOSE] Deleting game: %s\n", gameID)
+	}
+
+	// Delete the game
+	_, err := gamesClient.DeleteGame(ctx, &v1.DeleteGameRequest{Id: gameID})
+	if err != nil {
+		return fmt.Errorf("failed to delete game: %w", err)
+	}
+
+	// Format output
+	formatter := NewOutputFormatter()
+
+	if formatter.JSON {
+		data := map[string]any{
+			"game_id": gameID,
+			"deleted": true,
+		}
+		return formatter.PrintJSON(data)
+	}
+
+	return formatter.PrintText(fmt.Sprintf("Deleted game: %s\n", gameID))
+}

--- a/cmd/cli/cmd/new.go
+++ b/cmd/cli/cmd/new.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	v1 "github.com/turnforge/weewar/gen/go/weewar/v1/models"
+	"github.com/turnforge/weewar/lib"
+	"github.com/turnforge/weewar/services/connectclient"
+)
+
+var (
+	gameName          string
+	gameDescription   string
+	startingCoins     int32
+	gameIncome        int32
+	landbaseIncome    int32
+	navalbaseIncome   int32
+	airportbaseIncome int32
+)
+
+// newCmd represents the new command
+var newCmd = &cobra.Command{
+	Use:   "new <world_id>",
+	Short: "Create a new game from a world",
+	Long: `Create a new game from an existing world.
+Players are auto-detected from the world based on who owns units or tiles.
+Requires WEEWAR_SERVER to be set.
+
+Examples:
+  ww new 01bdc3ce                              Create game from world
+  ww new 01bdc3ce --name "My Game"             Create game with custom name
+  ww new 01bdc3ce --starting-coins 200         Start with 200 coins per player
+  ww new 01bdc3ce --landbase-income 100        Set landbase income to 100`,
+	Args: cobra.ExactArgs(1),
+	RunE: runNew,
+}
+
+func init() {
+	rootCmd.AddCommand(newCmd)
+	newCmd.Flags().StringVar(&gameName, "name", "", "name for the new game")
+	newCmd.Flags().StringVar(&gameDescription, "desc", "", "description for the new game")
+	newCmd.Flags().Int32Var(&startingCoins, "starting-coins", 100, "starting coins per player")
+	newCmd.Flags().Int32Var(&gameIncome, "game-income", 0, "base income per turn")
+	newCmd.Flags().Int32Var(&landbaseIncome, "landbase-income", 75, "income per landbase")
+	newCmd.Flags().Int32Var(&navalbaseIncome, "navalbase-income", 75, "income per navalbase")
+	newCmd.Flags().Int32Var(&airportbaseIncome, "airportbase-income", 75, "income per airport")
+}
+
+func runNew(cmd *cobra.Command, args []string) error {
+	worldID := args[0]
+	ctx := context.Background()
+
+	serverURL := getServerURL()
+	if serverURL == "" {
+		return fmt.Errorf("WEEWAR_SERVER is required for creating games (e.g., http://localhost:9080)")
+	}
+
+	// Create Connect clients
+	gamesClient := connectclient.NewConnectGamesClient(serverURL)
+	worldsClient := connectclient.NewConnectWorldsClient(serverURL)
+
+	if isVerbose() {
+		fmt.Printf("[VERBOSE] Using server: %s\n", serverURL)
+		fmt.Printf("[VERBOSE] Loading world: %s\n", worldID)
+	}
+
+	// Load world to auto-detect players
+	worldResp, err := worldsClient.GetWorld(ctx, &v1.GetWorldRequest{Id: worldID})
+	if err != nil {
+		return fmt.Errorf("failed to load world %s: %w", worldID, err)
+	}
+
+	if worldResp.WorldData == nil {
+		return fmt.Errorf("world %s has no data", worldID)
+	}
+
+	// Auto-detect players from world data
+	players := detectPlayersFromWorld(worldResp.WorldData)
+	if len(players) == 0 {
+		return fmt.Errorf("no players found in world (no units or tiles with player ownership)")
+	}
+
+	if isVerbose() {
+		fmt.Printf("[VERBOSE] Detected %d player(s): ", len(players))
+		for i, p := range players {
+			if i > 0 {
+				fmt.Print(", ")
+			}
+			fmt.Printf("Player %d", p.PlayerId)
+		}
+		fmt.Println()
+	}
+
+	// Build game name from world if not provided
+	name := gameName
+	if name == "" {
+		if worldResp.World != nil && worldResp.World.Name != "" {
+			name = worldResp.World.Name + " Game"
+		} else {
+			name = "Game from " + worldID
+		}
+	}
+
+	// Create game request
+	game := &v1.Game{
+		WorldId:     worldID,
+		Name:        name,
+		Description: gameDescription,
+		Config: &v1.GameConfiguration{
+			Players: players,
+			IncomeConfigs: &v1.IncomeConfig{
+				StartingCoins:     startingCoins,
+				GameIncome:        gameIncome,
+				LandbaseIncome:    landbaseIncome,
+				NavalbaseIncome:   navalbaseIncome,
+				AirportbaseIncome: airportbaseIncome,
+			},
+		},
+	}
+
+	// Create the game
+	resp, err := gamesClient.CreateGame(ctx, &v1.CreateGameRequest{Game: game})
+	if err != nil {
+		return fmt.Errorf("failed to create game: %w", err)
+	}
+
+	// Format output
+	formatter := NewOutputFormatter()
+
+	if formatter.JSON {
+		data := map[string]any{
+			"game_id":     resp.Game.Id,
+			"name":        resp.Game.Name,
+			"world_id":    resp.Game.WorldId,
+			"players":     len(players),
+			"description": resp.Game.Description,
+		}
+		return formatter.PrintJSON(data)
+	}
+
+	// Text output
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Created game: %s\n", resp.Game.Id))
+	sb.WriteString(fmt.Sprintf("  Name: %s\n", resp.Game.Name))
+	sb.WriteString(fmt.Sprintf("  World: %s\n", resp.Game.WorldId))
+	sb.WriteString(fmt.Sprintf("  Players: %d\n", len(players)))
+	if resp.Game.Description != "" {
+		sb.WriteString(fmt.Sprintf("  Description: %s\n", resp.Game.Description))
+	}
+	sb.WriteString(fmt.Sprintf("\nTo play: export WEEWAR_GAME_ID=%s\n", resp.Game.Id))
+
+	return formatter.PrintText(sb.String())
+}
+
+// detectPlayersFromWorld scans world data and returns GamePlayer entries
+// for each player that owns at least one unit or tile
+func detectPlayersFromWorld(worldData *v1.WorldData) []*v1.GamePlayer {
+	// Ensure maps are initialized
+	lib.MigrateWorldData(worldData)
+
+	playerSet := make(map[int32]bool)
+
+	// Check tiles
+	for _, tile := range worldData.TilesMap {
+		if tile != nil && tile.Player > 0 {
+			playerSet[tile.Player] = true
+		}
+	}
+
+	// Check units
+	for _, unit := range worldData.UnitsMap {
+		if unit != nil && unit.Player > 0 {
+			playerSet[unit.Player] = true
+		}
+	}
+
+	// Build sorted player list
+	var players []*v1.GamePlayer
+	for playerID := int32(1); playerID <= 8; playerID++ {
+		if playerSet[playerID] {
+			players = append(players, &v1.GamePlayer{
+				PlayerId:   playerID,
+				PlayerType: "human",
+				IsActive:   true,
+			})
+		}
+	}
+
+	return players
+}

--- a/services/connectclient/worlds_client.go
+++ b/services/connectclient/worlds_client.go
@@ -1,0 +1,78 @@
+package connectclient
+
+import (
+	"context"
+	"net/http"
+
+	"connectrpc.com/connect"
+	v1 "github.com/turnforge/weewar/gen/go/weewar/v1/models"
+	"github.com/turnforge/weewar/gen/go/weewar/v1/services/weewarv1connect"
+)
+
+// ConnectWorldsClient wraps a Connect client for the WorldsService
+type ConnectWorldsClient struct {
+	client weewarv1connect.WorldsServiceClient
+}
+
+// NewConnectWorldsClient creates a new Connect client for the WorldsService
+func NewConnectWorldsClient(serverURL string) *ConnectWorldsClient {
+	client := weewarv1connect.NewWorldsServiceClient(
+		http.DefaultClient,
+		serverURL,
+	)
+	return &ConnectWorldsClient{client: client}
+}
+
+// GetWorld returns a specific world with metadata via Connect
+func (c *ConnectWorldsClient) GetWorld(ctx context.Context, req *v1.GetWorldRequest) (*v1.GetWorldResponse, error) {
+	resp, err := c.client.GetWorld(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
+// ListWorlds returns all available worlds via Connect
+func (c *ConnectWorldsClient) ListWorlds(ctx context.Context, req *v1.ListWorldsRequest) (*v1.ListWorldsResponse, error) {
+	resp, err := c.client.ListWorlds(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
+// CreateWorld creates a new world via Connect
+func (c *ConnectWorldsClient) CreateWorld(ctx context.Context, req *v1.CreateWorldRequest) (*v1.CreateWorldResponse, error) {
+	resp, err := c.client.CreateWorld(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
+// UpdateWorld updates a world via Connect
+func (c *ConnectWorldsClient) UpdateWorld(ctx context.Context, req *v1.UpdateWorldRequest) (*v1.UpdateWorldResponse, error) {
+	resp, err := c.client.UpdateWorld(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
+// DeleteWorld deletes a world via Connect
+func (c *ConnectWorldsClient) DeleteWorld(ctx context.Context, req *v1.DeleteWorldRequest) (*v1.DeleteWorldResponse, error) {
+	resp, err := c.client.DeleteWorld(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
+// GetWorlds batch gets multiple worlds by ID via Connect
+func (c *ConnectWorldsClient) GetWorlds(ctx context.Context, req *v1.GetWorldsRequest) (*v1.GetWorldsResponse, error) {
+	resp, err := c.client.GetWorlds(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}


### PR DESCRIPTION
## Summary
- Add `ww new <world_id>` command to create games from the CLI
- Auto-detect players from world data based on unit/tile ownership
- Add `ConnectWorldsClient` for fetching world data via HTTP API

## Features
Configurable income settings via flags:
- `--name`: game name
- `--desc`: game description  
- `--starting-coins`: starting coins per player (default: 0)
- `--game-income`: base income per turn (default: 300)
- `--landbase-income`: income per landbase (default: 150)
- `--navalbase-income`: income per navalbase (default: 150)
- `--airportbase-income`: income per airport (default: 150)

## Usage
```bash
export WEEWAR_SERVER=http://localhost:9080
ww new 01bdc3ce --name "My Game"
```

## Test plan
- [x] Start server with `devloop`
- [x] Run `ww new <world_id>` with a valid world
- [x] Verify game is created and playable with `ww status`

Closes #30