### PR TITLE
Fix remote sync animations and attack-highlight handling (#46)

### DIFF
--- a/web/pages/GameViewerPage/GameViewerPageBase.ts
+++ b/web/pages/GameViewerPage/GameViewerPageBase.ts
@@ -655,8 +655,18 @@ export abstract class GameViewerPageBase extends BasePage implements LCMComponen
     }
 
     async moveUnit(request: MoveUnitRequest): Promise<MoveUnitResponse> {
-        if (request.unit && request.path) {
+        if (request.unit && request.path && request.path.length >= 2) {
+            // Animate the movement in scene first (needs sprite at old position)
             await this.gameScene.moveUnit(request.unit, request.path);
+
+            // Then update World data model: remove from old, set at new
+            const oldPos = request.path[0];
+            this.world.removeUnitAt(oldPos.q, oldPos.r);
+            this.world.setUnitDirect(request.unit);
+        } else if (request.unit) {
+            // Fallback: No valid path, just update unit at its current position
+            // This shouldn't happen with the Go-side fix, but handle gracefully
+            console.warn('[GameViewerPage] moveUnit called without valid path, unit:', request.unit);
             this.world.setUnitDirect(request.unit);
         }
         return {};


### PR DESCRIPTION
## Summary
- Add `FindPathTo` with efficient Dijkstra that stops when destination is reached
- Store reconstructed path in `ProcessMoveUnit` for animations
- Handle attack-highlight clicks in SceneClicked (was showing "Unhandled layer click")
- Fix path overwriting when `ReconstructedPath` is empty from remote sync
- Remove unit from old position before animation in browser

## Changes
- **lib/rules_engine.go**: Add `FindPathTo` with early exit Dijkstra
- **lib/moves.go**: Use `FindPathTo` to validate move and get full path in one call
- **services/gameview_presenter.go**: Add "attack-highlight" to switch case, fix path handling
- **web/pages/GameViewerPage/GameViewerPageBase.ts**: Remove unit from old position before animating

## Test plan
- [x] Run `go test ./lib/... ./services/... ./tests/...` - all pass
- [ ] Manually test movement animation with multi-step paths
- [ ] Manually test attack-highlight clicks execute attacks
- [ ] Manually test remote sync updates animate correctly