### PR TITLE
Add missing database indexes via GORM proto annotations

### DIFF
--- a/protos/weewar/v1/gorm/indexer.proto
+++ b/protos/weewar/v1/gorm/indexer.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package weewar.v1;
 
 import "dal/v1/annotations.proto";
+import "google/protobuf/timestamp.proto";
 import "weewar/v1/models/indexer.proto";
 
 option go_package = "github.com/turnforge/weewar/gen/gorm;weewargorm";
@@ -13,6 +14,26 @@ message IndexStateGORM {
     source: "weewar.v1.IndexState"
     table: "index_states"
   };
+
+  // Composite index for entity lookups: WHERE entity_type = ? AND entity_id = ?
+  string entity_type = 1 [(dal.v1.column) = {
+    gorm_tags: ["index:idx_index_states_entity,priority:1"]
+  }];
+  string entity_id = 2 [(dal.v1.column) = {
+    gorm_tags: ["index:idx_index_states_entity,priority:2"]
+  }];
+
+  // Index for range queries: WHERE indexed_at <= ?
+  // Used by indexer to find stale records
+  google.protobuf.Timestamp indexed_at = 3 [(dal.v1.column) = {
+    gorm_tags: ["index:idx_index_states_indexed_at"]
+  }];
+
+  // Partial index for finding records that need indexing
+  // Only indexes rows where needs_indexing = true (much smaller index)
+  bool needs_indexing = 4 [(dal.v1.column) = {
+    gorm_tags: ["index:idx_index_states_needs_indexing,where:needs_indexing"]
+  }];
 }
 
 // IndexRecord represents a single record within an LRO (stored as JSONB)

--- a/protos/weewar/v1/gorm/models.proto
+++ b/protos/weewar/v1/gorm/models.proto
@@ -91,6 +91,11 @@ message GameGORM {
     gorm_tags: ["primaryKey"]
   }];
 
+  // world_id indexed for queries filtering games by world
+  string world_id = 3 [(dal.v1.column) = {
+    gorm_tags: ["index:idx_games_world_id"]
+  }];
+
   // Tags as JSON for cross-DB compatibility
   repeated string tags = 7 [(dal.v1.column) = {
     gorm_tags: ["serializer:json"]
@@ -194,8 +199,11 @@ message GameMoveGroupGORM {
 message GameMoveGORM {
   option (dal.v1.gorm) = { source: "weewar.v1.GameMove", table: "game_moves" };
 
-  string game_id = 1 [(dal.v1.column) = { gorm_tags: ["primaryKey"] }];
-  int64 group_number = 2 [(dal.v1.column) = { gorm_tags: ["primaryKey"] }];
+  // game_id is indexed for queries like WHERE game_id = ? ORDER BY group_number
+  // Also part of composite index idx_game_moves_lookup for range queries
+  string game_id = 1 [(dal.v1.column) = { gorm_tags: ["primaryKey", "index:idx_game_moves_game_id", "index:idx_game_moves_lookup,priority:1"] }];
+  // group_number is part of composite index for queries like WHERE game_id = ? AND group_number >= ?
+  int64 group_number = 2 [(dal.v1.column) = { gorm_tags: ["primaryKey", "index:idx_game_moves_lookup,priority:2"] }];
   int64 move_number = 3 [(dal.v1.column) = { gorm_tags: ["primaryKey"] }];
 
   // Version number for optimistic locking


### PR DESCRIPTION
- Add indexes to GameMoveGORM:
  - idx_game_moves_game_id for WHERE game_id = ? queries
  - idx_game_moves_lookup composite (game_id, group_number) for range queries

- Add indexes to GameGORM:
  - idx_games_world_id for filtering games by world

- Add indexes to IndexStateGORM:
  - idx_index_states_entity composite (entity_type, entity_id)
  - idx_index_states_indexed_at for range queries
  - idx_index_states_needs_indexing for finding records needing indexing

Addresses Critical Issue #6 from performance analysis