### PR TITLE
Redirect users to home page after logout

### DIFF
--- a/web/templates/ProfilePage.html
+++ b/web/templates/ProfilePage.html
@@ -213,7 +213,7 @@
                     </h2>
 
                     <div class="flex flex-wrap gap-3">
-                        <a href="/auth/logout"
+                        <a href="/auth/logout?to=/"
                            class="inline-flex items-center px-4 py-2 border border-red-300 dark:border-red-600 text-sm font-medium rounded-lg text-red-700 dark:text-red-400 bg-white dark:bg-gray-800 hover:bg-red-50 dark:hover:bg-red-900/20 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 dark:focus:ring-offset-gray-800 transition-colors">
                             <svg class="h-4 w-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>


### PR DESCRIPTION
The oneauth library's logout handler supports a 'to' query parameter for specifying the redirect destination. Previously the logout link had no redirect parameter, causing users to see a plain "Logged Out" message. Now users are redirected to the home page after logout.