### PR TITLE
Debug Google auth callback URL returning 404

### DIFF
--- a/web/templates/LoginPage.html
+++ b/web/templates/LoginPage.html
@@ -175,7 +175,7 @@
                 <!-- Social Login Buttons -->
                 <div class="space-y-3">
                     {{if .Config.EnableGoogleLogin}}
-                    <a href="/auth/google/?callbackURL={{.CallbackURL}}"
+                    <a href="/auth/google?callbackURL={{.CallbackURL}}"
                        class="w-full inline-flex items-center justify-center py-3 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition duration-150 ease-in-out">
                         <svg class="w-5 h-5 mr-3" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
@@ -188,7 +188,7 @@
                     {{end}}
 
                     {{if .Config.EnableGitHubLogin}}
-                    <a href="/auth/github/?callbackURL={{.CallbackURL}}"
+                    <a href="/auth/github?callbackURL={{.CallbackURL}}"
                        class="w-full inline-flex items-center justify-center py-3 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition duration-150 ease-in-out">
                         <svg class="w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 24 24">
                             <path fill-rule="evenodd" d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" clip-rule="evenodd"/>
@@ -198,7 +198,7 @@
                     {{end}}
 
                     {{if .EnableTwitterLogin}}
-                    <a href="/auth/twitter/?callbackURL={{.CallbackURL}}"
+                    <a href="/auth/twitter?callbackURL={{.CallbackURL}}"
                        class="w-full inline-flex items-center justify-center py-3 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition duration-150 ease-in-out">
                         <svg class="w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
@@ -208,7 +208,7 @@
                     {{end}}
 
                     {{if .Config.EnableMicrosoftLogin}}
-                    <a href="/auth/microsoft/?callbackURL={{.CallbackURL}}"
+                    <a href="/auth/microsoft?callbackURL={{.CallbackURL}}"
                        class="w-full inline-flex items-center justify-center py-3 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition duration-150 ease-in-out">
                         <svg class="w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 23 23">
                             <path fill="#f35325" d="M0 0h11v11H0z"/>
@@ -221,7 +221,7 @@
                     {{end}}
 
                     {{if .Config.EnableAppleLogin}}
-                    <a href="/auth/apple/?callbackURL={{.CallbackURL}}"
+                    <a href="/auth/apple?callbackURL={{.CallbackURL}}"
                        class="w-full inline-flex items-center justify-center py-3 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition duration-150 ease-in-out">
                         <svg class="w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>


### PR DESCRIPTION
The oneauth library's AddAuth method strips trailing slashes when registering routes, but LoginPage.html had URLs with trailing slashes (e.g., /auth/google/?callbackURL=). This caused route mismatches:

1. Request for /auth/google/ arrives
2. StripPrefix removes /auth, leaving /google/
3. oneauth's mux only has handler at /google (no trailing slash)
4. No match -> 404

Remove trailing slashes from all OAuth provider URLs to match how oneauth registers routes.