### PR TITLE
Fix login redirect on new world creation

### DIFF
--- a/web/server/SelectWorldPage.go
+++ b/web/server/SelectWorldPage.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 
 	goal "github.com/panyam/goapplib"
@@ -13,6 +14,18 @@ type SelectWorldPage struct {
 }
 
 func (m *SelectWorldPage) Load(r *http.Request, w http.ResponseWriter, app *goal.App[*WeewarApp]) (err error, finished bool) {
+	// Require login to select a world for game creation
+	ctx := app.Context
+	loggedInUserId := ctx.AuthMiddleware.GetLoggedInUserId(r)
+	if loggedInUserId == "" {
+		qs := r.URL.RawQuery
+		if len(qs) > 0 {
+			qs = "?" + qs
+		}
+		http.Redirect(w, r, fmt.Sprintf("/login?callbackURL=%s", fmt.Sprintf("/worlds/select%s", qs)), http.StatusSeeOther)
+		return nil, true
+	}
+
 	m.Title = "Select a World"
 	m.DisableSplashScreen = true
 	m.Header.Load(r, w, app)

--- a/web/server/StartGamePage.go
+++ b/web/server/StartGamePage.go
@@ -29,6 +29,18 @@ type StartGamePage struct {
 }
 
 func (p *StartGamePage) Load(r *http.Request, w http.ResponseWriter, app *goal.App[*WeewarApp]) (err error, finished bool) {
+	// Require login to start a game
+	ctx := app.Context
+	loggedInUserId := ctx.AuthMiddleware.GetLoggedInUserId(r)
+	if loggedInUserId == "" {
+		qs := r.URL.RawQuery
+		if len(qs) > 0 {
+			qs = "?" + qs
+		}
+		http.Redirect(w, r, fmt.Sprintf("/login?callbackURL=%s", fmt.Sprintf("/games/start%s", qs)), http.StatusSeeOther)
+		return nil, true
+	}
+
 	// Get worldId from query parameter (optional)
 	p.WorldId = r.URL.Query().Get("worldId")
 

--- a/web/server/WorldCreatePage.go
+++ b/web/server/WorldCreatePage.go
@@ -27,6 +27,16 @@ func (p *WorldCreatePage) Load(r *http.Request, w http.ResponseWriter, app *goal
 	ctx := app.Context
 	loggedInUserId := ctx.AuthMiddleware.GetLoggedInUserId(r)
 
+	// Require login to access the create world page
+	if loggedInUserId == "" {
+		qs := r.URL.RawQuery
+		if len(qs) > 0 {
+			qs = "?" + qs
+		}
+		http.Redirect(w, r, fmt.Sprintf("/login?callbackURL=%s", fmt.Sprintf("/worlds/create%s", qs)), http.StatusSeeOther)
+		return nil, true
+	}
+
 	if r.Method == http.MethodPost {
 		// Handle form submission
 		if err := r.ParseForm(); err != nil {


### PR DESCRIPTION
WorldCreatePage, StartGamePage, and SelectWorldPage were showing forms to unauthenticated users instead of redirecting to login first.

Added login checks at the start of each page's Load() method following the established pattern from GameCreatorPage and ProfilePage.