### PR TITLE
Create FixSimulatorPage with matching design

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,6 +132,7 @@ func (b *Backend) SetupApp() *utils.App {
 			"/weewar.v1.GamesService/GetGame",
 			"/weewar.v1.GamesService/GetGames",
 			"/weewar.v1.GamesService/SimulateAttack",
+			"/weewar.v1.GamesService/SimulateFix",
 			// GameSync - allow spectating without login
 			"/weewar.v1.GameSyncService/Subscribe",
 		},

--- a/protos/weewar/v1/models/games_service.proto
+++ b/protos/weewar/v1/models/games_service.proto
@@ -302,3 +302,27 @@ message SimulateAttackResponse {
   double attacker_kill_probability = 5;
   double defender_kill_probability = 6;
 }
+
+/**
+ * Request for simulating fix (repair) between two units
+ */
+message SimulateFixRequest {
+  int32 fixing_unit_type = 1;    // Unit type performing the fix
+  int32 fixing_unit_health = 2;  // Health of the fixing unit (Hf)
+  int32 injured_unit_type = 3;   // Unit type being repaired (for display)
+  int32 num_simulations = 4;     // Default: 1000
+}
+
+/**
+ * Response containing health restoration distribution statistics
+ */
+message SimulateFixResponse {
+  // Health restoration distribution: health_restored -> number_of_occurrences
+  map<int32, int32> healing_distribution = 1;
+
+  // Statistical summary
+  double mean_healing = 2;
+
+  // The fix value (F) of the fixing unit type
+  int32 fix_value = 3;
+}

--- a/protos/weewar/v1/services/games.proto
+++ b/protos/weewar/v1/services/games.proto
@@ -103,5 +103,16 @@ service GamesService {
       body: "*",
     };
   }
+
+  /**
+   * Simulates fix (repair) action to generate health restoration distributions
+   * This is a stateless utility method that doesn't require game state
+   */
+  rpc SimulateFix(SimulateFixRequest) returns (SimulateFixResponse) {
+    option (google.api.http) = {
+      post: "/v1/games/simulate_fix",
+      body: "*",
+    };
+  }
 }
 

--- a/services/games_service.go
+++ b/services/games_service.go
@@ -37,6 +37,10 @@ type GamesService interface {
 	// Simulates combat between two units to generate damage distributions
 	// This is a stateless utility method that doesn't require game state
 	SimulateAttack(context.Context, *v1.SimulateAttackRequest) (*v1.SimulateAttackResponse, error)
+	// *
+	// Simulates fix (repair) action to generate health restoration distributions
+	// This is a stateless utility method that doesn't require game state
+	SimulateFix(context.Context, *v1.SimulateFixRequest) (*v1.SimulateFixResponse, error)
 	GetRuntimeGame(game *v1.Game, gameState *v1.GameState) (*lib.Game, error)
 
 	// SaveMoveGroup saves a move group atomically with the game state.
@@ -308,6 +312,80 @@ func (s *BaseGamesService) SimulateAttack(ctx context.Context, req *v1.SimulateA
 	resp.DefenderMeanDamage = defenderMeanDamage
 	resp.AttackerKillProbability = float64(attackerKillCount) / float64(numSims)
 	resp.DefenderKillProbability = float64(defenderKillCount) / float64(numSims)
+
+	return resp, nil
+}
+
+// SimulateFix simulates fix (repair) action and returns health restoration distribution
+func (s *BaseGamesService) SimulateFix(ctx context.Context, req *v1.SimulateFixRequest) (resp *v1.SimulateFixResponse, err error) {
+	resp = &v1.SimulateFixResponse{}
+
+	// Set default number of simulations if not provided
+	numSims := req.NumSimulations
+	if numSims <= 0 {
+		numSims = 1000
+	}
+
+	// Get rules engine
+	rulesEngine := lib.DefaultRulesEngine()
+
+	// Get the fixing unit's fix_value from unit definition
+	fixingUnitDef, err := rulesEngine.GetUnitData(req.FixingUnitType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get fixing unit data: %w", err)
+	}
+
+	fixValue := fixingUnitDef.FixValue
+	if fixValue <= 0 {
+		// Unit cannot fix, return empty distribution
+		resp.HealingDistribution = make(map[int32]int32)
+		resp.MeanHealing = 0
+		resp.FixValue = 0
+		return resp, nil
+	}
+
+	// Create mock units for simulation
+	fixingUnit := &v1.Unit{
+		Q:               0,
+		R:               0,
+		Player:          1,
+		UnitType:        req.FixingUnitType,
+		AvailableHealth: req.FixingUnitHealth,
+	}
+	injuredUnit := &v1.Unit{
+		Q:               1,
+		R:               0,
+		Player:          1,
+		UnitType:        req.InjuredUnitType,
+	}
+
+	// Create fix context
+	fixCtx := &lib.FixContext{
+		FixingUnit:       fixingUnit,
+		FixingUnitHealth: req.FixingUnitHealth,
+		FixValue:         fixValue,
+		InjuredUnit:      injuredUnit,
+	}
+
+	// Generate fix distribution
+	fixDist, err := rulesEngine.GenerateFixDistribution(fixCtx, int(numSims))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate fix distribution: %w", err)
+	}
+
+	// Convert distribution to map
+	healingMap := make(map[int32]int32)
+	meanHealing := 0.0
+	for _, healRange := range fixDist.Ranges {
+		healing := int32(healRange.MinValue)
+		count := int32(float64(numSims) * healRange.Probability)
+		healingMap[healing] = count
+		meanHealing += healRange.MinValue * healRange.Probability
+	}
+
+	resp.HealingDistribution = healingMap
+	resp.MeanHealing = meanHealing
+	resp.FixValue = fixValue
 
 	return resp, nil
 }

--- a/web/pages/FixSimulatorPage.ts
+++ b/web/pages/FixSimulatorPage.ts
@@ -1,0 +1,297 @@
+import { BasePage, EventBus, LCMComponent, LifecycleController } from '@panyam/tsappkit';
+import { ITheme } from '../assets/themes/BaseTheme';
+import DefaultTheme from '../assets/themes/default';
+import WeewarBundle from '../gen/wasmjs';
+import { GamesServiceClient } from '../gen/wasmjs/weewar/v1/services/gamesServiceClient';
+import { SimulateFixRequest, SimulateFixResponse } from '../gen/wasmjs/weewar/v1/models/interfaces';
+
+/**
+ * Fix Simulator Page - Interactive repair simulator
+ * Allows users to simulate fix (repair) outcomes between different units
+ */
+class FixSimulatorPage extends BasePage {
+    private wasmBundle: WeewarBundle | null = null;
+    private gamesClient: GamesServiceClient | null = null;
+    private theme: ITheme;
+
+    // Canvas/container elements
+    private fixingHexContainer: HTMLElement;
+    private injuredHexContainer: HTMLElement;
+    private healingChartCanvas: HTMLCanvasElement;
+
+    // Form elements
+    private fixingUnitSelect: HTMLSelectElement;
+    private fixingUnitHealthInput: HTMLInputElement;
+    private injuredUnitSelect: HTMLSelectElement;
+    private numSimulationsInput: HTMLInputElement;
+    private simulateButton: HTMLButtonElement;
+
+    // Stat elements
+    private meanHealingEl: HTMLElement;
+    private fixValueEl: HTMLElement;
+
+    // Description elements
+    private fixingUnitNameEl: HTMLElement;
+    private injuredUnitNameEl: HTMLElement;
+
+    constructor() {
+        super('fix-simulator-page', new EventBus(), false);
+        this.theme = new DefaultTheme();
+    }
+
+    // Override lifecycle methods from BasePage
+    protected override initializeSpecificComponents(): LCMComponent[] {
+        // Get container elements
+        this.fixingHexContainer = document.getElementById('fixing-hex-container')!;
+        this.injuredHexContainer = document.getElementById('injured-hex-container')!;
+        this.healingChartCanvas = document.getElementById('healing-chart') as HTMLCanvasElement;
+
+        // Get form elements
+        this.fixingUnitSelect = document.getElementById('fixing-unit') as HTMLSelectElement;
+        this.fixingUnitHealthInput = document.getElementById('fixing-unit-health') as HTMLInputElement;
+        this.injuredUnitSelect = document.getElementById('injured-unit') as HTMLSelectElement;
+        this.numSimulationsInput = document.getElementById('num-simulations') as HTMLInputElement;
+        this.simulateButton = document.getElementById('simulate-btn') as HTMLButtonElement;
+
+        // Get stat elements
+        this.meanHealingEl = document.getElementById('mean-healing')!;
+        this.fixValueEl = document.getElementById('fix-value')!;
+
+        // Get description elements
+        this.fixingUnitNameEl = document.getElementById('fixing-unit-name')!;
+        this.injuredUnitNameEl = document.getElementById('injured-unit-name')!;
+
+        // Initialize async components
+        this.initAsync();
+
+        // No child components
+        return [];
+    }
+
+    protected override bindSpecificEvents(): void {
+        // Simulate button
+        this.simulateButton.addEventListener('click', () => this.runSimulation());
+
+        // Auto-simulate on form changes
+        const autoSimulate = () => this.runSimulation();
+        this.fixingUnitSelect.addEventListener('change', autoSimulate);
+        this.fixingUnitHealthInput.addEventListener('input', autoSimulate);
+        this.injuredUnitSelect.addEventListener('change', autoSimulate);
+        this.numSimulationsInput.addEventListener('input', autoSimulate);
+    }
+
+    private async initAsync(): Promise<void> {
+        // Load WASM
+        await this.loadWASM();
+
+        // Run initial simulation (dropdowns are already populated server-side)
+        await this.runSimulation();
+    }
+
+    private async loadWASM(): Promise<void> {
+        try {
+            console.log('[FixSimulator] Loading WASM bundle...');
+            this.wasmBundle = new WeewarBundle();
+            this.gamesClient = new GamesServiceClient(this.wasmBundle);
+            await this.wasmBundle.loadWasm('/static/wasm/weewar-cli.wasm');
+            await this.wasmBundle.waitUntilReady();
+            console.log('[FixSimulator] WASM loaded successfully');
+        } catch (error) {
+            console.error('[FixSimulator] Failed to load WASM:', error);
+            alert('Failed to load game engine');
+        }
+    }
+
+    private async runSimulation(): Promise<void> {
+        if (!this.gamesClient) {
+            console.error('[FixSimulator] WASM not loaded yet');
+            return;
+        }
+
+        // Build request
+        const request: SimulateFixRequest = {
+            fixingUnitType: parseInt(this.fixingUnitSelect.value),
+            fixingUnitHealth: parseInt(this.fixingUnitHealthInput.value),
+            injuredUnitType: parseInt(this.injuredUnitSelect.value),
+            numSimulations: parseInt(this.numSimulationsInput.value),
+        };
+
+        console.log('[FixSimulator] Running simulation with:', request);
+
+        try {
+            // Call WASM RPC
+            const response: SimulateFixResponse = await this.gamesClient.simulateFix(request);
+            console.log('[FixSimulator] Simulation result:', response);
+
+            // Update visualizations
+            await this.renderHexes(request);
+            this.renderChart(response);
+            this.updateStats(response);
+            this.updateDescription();
+        } catch (error) {
+            console.error('[FixSimulator] Simulation failed:', error);
+            alert('Simulation failed: ' + error);
+        }
+    }
+
+    private async renderHexes(request: SimulateFixRequest): Promise<void> {
+        console.log('[FixSimulator] renderHexes - request:', request);
+
+        // Clear containers
+        this.fixingHexContainer.innerHTML = '';
+        this.injuredHexContainer.innerHTML = '';
+
+        // Create container divs for units (use grass terrain as background)
+        const fixingTerrainDiv = document.createElement('div');
+        fixingTerrainDiv.className = 'relative w-32 h-32 mx-auto';
+        this.fixingHexContainer.appendChild(fixingTerrainDiv);
+
+        const injuredTerrainDiv = document.createElement('div');
+        injuredTerrainDiv.className = 'relative w-32 h-32 mx-auto';
+        this.injuredHexContainer.appendChild(injuredTerrainDiv);
+
+        // Render grass terrain (ID 1) as background for both
+        console.log('[FixSimulator] Loading terrain backgrounds');
+        await this.theme.setTileImage(1, 0, fixingTerrainDiv);
+        await this.theme.setTileImage(1, 0, injuredTerrainDiv);
+
+        // Create overlay divs for units on top of terrain
+        const fixingUnitDiv = document.createElement('div');
+        fixingUnitDiv.className = 'absolute inset-0 w-full h-full';
+        fixingTerrainDiv.appendChild(fixingUnitDiv);
+
+        const injuredUnitDiv = document.createElement('div');
+        injuredUnitDiv.className = 'absolute inset-0 w-full h-full';
+        injuredTerrainDiv.appendChild(injuredUnitDiv);
+
+        // Render unit images (both use player 1 = blue since they're friendly)
+        console.log('[FixSimulator] Loading fixing unit:', request.fixingUnitType);
+        await this.theme.setUnitImage(request.fixingUnitType, 1, fixingUnitDiv);
+        console.log('[FixSimulator] Loading injured unit:', request.injuredUnitType);
+        await this.theme.setUnitImage(request.injuredUnitType, 1, injuredUnitDiv);
+        console.log('[FixSimulator] renderHexes complete');
+
+        // Add health label below the fixing unit hex
+        const fixingHealthLabel = document.createElement('div');
+        fixingHealthLabel.className = 'text-center mt-2 font-semibold text-gray-900 dark:text-white';
+        fixingHealthLabel.textContent = `HP: ${request.fixingUnitHealth}`;
+        this.fixingHexContainer.appendChild(fixingHealthLabel);
+
+        // Injured unit doesn't need health label (it's about restoration, not current health)
+    }
+
+    private renderChart(response: SimulateFixResponse): void {
+        console.log('[FixSimulator] renderChart - healing dist:', response.healingDistribution);
+
+        // Render healing distribution
+        this.drawBarChart(
+            this.healingChartCanvas,
+            response.healingDistribution,
+            'Health Restored',
+            '#10b981' // Green color for healing
+        );
+    }
+
+    private drawBarChart(
+        canvas: HTMLCanvasElement,
+        distribution: { [key: number]: number },
+        title: string,
+        color: string
+    ): void {
+        console.log(`[FixSimulator] drawBarChart - ${title}:`, distribution);
+
+        const ctx = canvas.getContext('2d')!;
+        const width = canvas.width;
+        const height = canvas.height;
+
+        // Clear canvas
+        ctx.clearRect(0, 0, width, height);
+
+        // Convert distribution to sorted array
+        const data = Object.entries(distribution)
+            .map(([healing, count]) => ({ healing: parseInt(healing), count }))
+            .sort((a, b) => a.healing - b.healing);
+
+        console.log(`[FixSimulator] drawBarChart - ${title} data array:`, data);
+
+        if (data.length === 0) {
+            console.warn(`[FixSimulator] drawBarChart - ${title} has no data!`);
+            // Draw a message indicating no data
+            ctx.fillStyle = this.isDarkMode() ? '#fff' : '#000';
+            ctx.font = '14px sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('This unit cannot perform repairs (Fix Value = 0)', width / 2, height / 2);
+            return;
+        }
+
+        // Chart dimensions
+        const padding = 40;
+        const chartWidth = width - 2 * padding;
+        const chartHeight = height - 2 * padding;
+
+        // Find max count for scaling
+        const maxCount = Math.max(...data.map(d => d.count));
+
+        // Bar width
+        const barWidth = chartWidth / data.length;
+
+        // Draw bars
+        data.forEach((d, i) => {
+            const barHeight = (d.count / maxCount) * chartHeight;
+            const x = padding + i * barWidth;
+            const y = height - padding - barHeight;
+
+            ctx.fillStyle = color;
+            ctx.fillRect(x, y, barWidth * 0.8, barHeight);
+
+            // Draw healing value below bar
+            ctx.fillStyle = this.isDarkMode() ? '#fff' : '#000';
+            ctx.font = '10px sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText(d.healing.toString(), x + barWidth * 0.4, height - padding + 15);
+        });
+
+        // Draw axes
+        ctx.strokeStyle = this.isDarkMode() ? '#666' : '#ccc';
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(padding, height - padding);
+        ctx.lineTo(width - padding, height - padding);
+        ctx.moveTo(padding, padding);
+        ctx.lineTo(padding, height - padding);
+        ctx.stroke();
+    }
+
+    private updateStats(response: SimulateFixResponse): void {
+        this.meanHealingEl.textContent = response.meanHealing.toFixed(2);
+        this.fixValueEl.textContent = response.fixValue.toString();
+    }
+
+    private updateDescription(): void {
+        // Update the unit names in the description
+        const fixingUnitOption = this.fixingUnitSelect.selectedOptions[0];
+        const injuredUnitOption = this.injuredUnitSelect.selectedOptions[0];
+
+        // Extract just the unit name (before any parentheses)
+        const fixingUnitName = fixingUnitOption?.textContent?.split('(')[0]?.trim() || 'Unknown';
+        const injuredUnitName = injuredUnitOption?.textContent || 'Unknown';
+
+        this.fixingUnitNameEl.textContent = fixingUnitName;
+        this.injuredUnitNameEl.textContent = injuredUnitName;
+    }
+
+    private isDarkMode(): boolean {
+        return document.documentElement.classList.contains('dark');
+    }
+}
+
+// Initialize the page when DOM is ready
+document.addEventListener('DOMContentLoaded', async () => {
+    const page = new FixSimulatorPage();
+
+    // Create lifecycle controller with debug logging
+    const lifecycleController = new LifecycleController(page.eventBus, LifecycleController.DefaultConfig);
+
+    // Start breadth-first initialization
+    await lifecycleController.initializeFromRoot(page);
+});

--- a/web/server/FixSimulatorPage.go
+++ b/web/server/FixSimulatorPage.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"net/http"
+	"sort"
+
+	goal "github.com/panyam/goapplib"
+	"github.com/turnforge/weewar/lib"
+)
+
+type FixSimulatorPage struct {
+	BasePage
+	Header Header
+
+	// URL parameters for pre-populating form
+	FixingUnit       string
+	FixingUnitHealth string
+	InjuredUnit      string
+	NumSimulations   string
+
+	// Units data for dropdowns
+	// FixingUnits only includes units with fix_value > 0
+	FixingUnits []UnitType
+	// AllUnits includes all units (for injured unit dropdown)
+	AllUnits []UnitType
+	Theme    string
+}
+
+func (p *FixSimulatorPage) Load(r *http.Request, w http.ResponseWriter, app *goal.App[*WeewarApp]) (err error, finished bool) {
+	p.DisableSplashScreen = true
+	p.Title = "Fix Simulator"
+	p.Header.Load(r, w, app)
+
+	// Read URL parameters for pre-populating form
+	query := r.URL.Query()
+	p.FixingUnit = getQueryOrDefault(query, "fixingUnit", "39")       // Default: Aircraft Carrier (has fix ability)
+	p.FixingUnitHealth = getQueryOrDefault(query, "fixingUnitHealth", "10")
+	p.InjuredUnit = getQueryOrDefault(query, "injuredUnit", "17")     // Default: Bomber
+	p.NumSimulations = getQueryOrDefault(query, "numSims", "1000")
+	p.Theme = getQueryOrDefaultStr(query, "theme", "default")
+
+	// Load unit data
+	p.loadUnitData()
+
+	return nil, false
+}
+
+func (p *FixSimulatorPage) loadUnitData() {
+	themeName := p.Theme
+	useTheme := themeName != "default"
+	tm := GetThemeManager()
+	rulesEngine := lib.DefaultRulesEngine()
+
+	// Load all units, separating fixing units (with fix_value > 0)
+	p.FixingUnits = []UnitType{}
+	p.AllUnits = []UnitType{}
+
+	for _, unitID := range AllowedUnitIDs {
+		unitData, err := rulesEngine.GetUnitData(unitID)
+		if unitData != nil && err == nil {
+			iconDataURL := tm.GetUnitIconURL(unitID, useTheme, themeName)
+			themedUnitData := unitData
+			themedUnitData.Name = tm.GetUnitName(unitID, unitData.Name, useTheme, themeName)
+
+			unitType := UnitType{
+				UnitDefinition: themedUnitData,
+				IconDataURL:    iconDataURL,
+			}
+
+			p.AllUnits = append(p.AllUnits, unitType)
+
+			// Only add to FixingUnits if it has fix_value > 0
+			if unitData.FixValue > 0 {
+				p.FixingUnits = append(p.FixingUnits, unitType)
+			}
+		}
+	}
+
+	// Sort units alphabetically by name
+	sortAlphabetically := true
+	if sortAlphabetically {
+		sort.Slice(p.AllUnits, func(i, j int) bool { return p.AllUnits[i].Name < p.AllUnits[j].Name })
+		sort.Slice(p.FixingUnits, func(i, j int) bool { return p.FixingUnits[i].Name < p.FixingUnits[j].Name })
+	} else {
+		sort.Slice(p.AllUnits, func(i, j int) bool { return p.AllUnits[i].Id < p.AllUnits[j].Id })
+		sort.Slice(p.FixingUnits, func(i, j int) bool { return p.FixingUnits[i].Id < p.FixingUnits[j].Id })
+	}
+}

--- a/web/server/RulesGroup.go
+++ b/web/server/RulesGroup.go
@@ -16,5 +16,8 @@ func (g *RulesGroup) RegisterRoutes(app *goal.App[*WeewarApp]) *http.ServeMux {
 	// Attack simulator page
 	goal.Register[*AttackSimulatorPage](app, mux, "/attacksim")
 
+	// Fix (repair) simulator page
+	goal.Register[*FixSimulatorPage](app, mux, "/fixsim")
+
 	return mux
 }

--- a/web/templates/FixSimulatorPage.html
+++ b/web/templates/FixSimulatorPage.html
@@ -1,0 +1,244 @@
+<!-- templates/FixSimulatorPage.html -->
+{{# include "BasePage.html" #}}
+
+{{ define "ExtraHeadSection" }}
+<style>
+    .chart-canvas {
+        border: 1px solid #d1d5db;
+    }
+
+    .dark .chart-canvas {
+        border-color: #4b5563;
+    }
+
+    .form-label {
+        display: block;
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: #374151;
+        margin-bottom: 0.25rem;
+    }
+
+    .dark .form-label {
+        color: #d1d5db;
+    }
+
+    .form-select {
+        display: block;
+        width: 100%;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid #d1d5db;
+        border-radius: 0.375rem;
+        box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+        background-color: #ffffff;
+        color: #111827;
+    }
+
+    .form-select:focus {
+        outline: 2px solid transparent;
+        outline-offset: 2px;
+        box-shadow: 0 0 0 2px #3b82f6;
+        border-color: #3b82f6;
+    }
+
+    .dark .form-select {
+        border-color: #4b5563;
+        background-color: #374151;
+        color: #f9fafb;
+    }
+
+    .form-input {
+        display: block;
+        width: 100%;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid #d1d5db;
+        border-radius: 0.375rem;
+        box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+        background-color: #ffffff;
+        color: #111827;
+    }
+
+    .form-input:focus {
+        outline: 2px solid transparent;
+        outline-offset: 2px;
+        box-shadow: 0 0 0 2px #3b82f6;
+        border-color: #3b82f6;
+    }
+
+    .dark .form-input {
+        border-color: #4b5563;
+        background-color: #374151;
+        color: #f9fafb;
+    }
+
+    .stat-card {
+        background-color: #f9fafb;
+        border-radius: 0.375rem;
+        padding: 0.5rem;
+        text-align: center;
+    }
+
+    .dark .stat-card {
+        background-color: #374151;
+    }
+
+    .stat-label {
+        font-size: 0.75rem;
+        color: #4b5563;
+    }
+
+    .dark .stat-label {
+        color: #9ca3af;
+    }
+
+    .stat-value {
+        font-size: 1.125rem;
+        font-weight: 700;
+        color: #111827;
+    }
+
+    .dark .stat-value {
+        color: #f9fafb;
+    }
+
+    /* Number input spinner buttons */
+    input[type=number]::-webkit-inner-spin-button,
+    input[type=number]::-webkit-outer-spin-button {
+        opacity: 1;
+    }
+</style>
+{{ end }}
+
+{{ define "BodySection" }}
+<main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="mb-6">
+        <h1 class="text-3xl font-bold text-gray-900 dark:text-white">Fix Simulator</h1>
+        <p class="mt-2 text-gray-600 dark:text-gray-400">Simulate repair outcomes between different units</p>
+    </div>
+
+    <!-- Row 1: Configuration -->
+    <div class="grid grid-cols-2 gap-6 mb-6">
+        <!-- Fixing Unit Configuration -->
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border border-gray-200 dark:border-gray-700">
+            <h2 class="text-xl font-bold text-gray-900 dark:text-white mb-4">Fixing Unit</h2>
+
+            <div class="space-y-3">
+                <div>
+                    <label for="fixing-unit" class="form-label">Unit Type</label>
+                    <select id="fixing-unit" class="form-select">
+                        {{range .FixingUnits}}
+                        <option value="{{.Id}}" {{if eq .Id (Int $.FixingUnit)}}selected{{end}} data-icon="{{.IconDataURL}}" data-fix-value="{{.FixValue}}">{{.Name}} (Fix: {{.FixValue}})</option>
+                        {{end}}
+                    </select>
+                </div>
+
+                <div>
+                    <label for="fixing-unit-health" class="form-label">Health</label>
+                    <input type="number" id="fixing-unit-health" min="1" max="15" value="{{.FixingUnitHealth}}" class="form-input">
+                </div>
+            </div>
+        </div>
+
+        <!-- Injured Unit Configuration -->
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border border-gray-200 dark:border-gray-700">
+            <h2 class="text-xl font-bold text-gray-900 dark:text-white mb-4">Injured Unit</h2>
+
+            <div class="space-y-3">
+                <div>
+                    <label for="injured-unit" class="form-label">Unit Type</label>
+                    <select id="injured-unit" class="form-select">
+                        {{range .AllUnits}}
+                        <option value="{{.Id}}" {{if eq .Id (Int $.InjuredUnit)}}selected{{end}} data-icon="{{.IconDataURL}}">{{.Name}}</option>
+                        {{end}}
+                    </select>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Row 2: Hex Visualizations -->
+    <div class="grid grid-cols-2 gap-6 mb-6">
+        <!-- Fixing Unit Hex -->
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border border-gray-200 dark:border-gray-700">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2 text-center">Fixing Unit</h3>
+            <div id="fixing-hex-container" class="min-h-[150px]"></div>
+        </div>
+
+        <!-- Injured Unit Hex -->
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border border-gray-200 dark:border-gray-700">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2 text-center">Injured Unit</h3>
+            <div id="injured-hex-container" class="min-h-[150px]"></div>
+        </div>
+    </div>
+
+    <!-- Row 3: Health Restoration Distribution -->
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border border-gray-200 dark:border-gray-700 mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Health Restoration</h3>
+        <p id="chart-description" class="text-sm text-gray-600 dark:text-gray-400 mb-4">The amount of health <span id="fixing-unit-name">-</span> restores to <span id="injured-unit-name">-</span>.</p>
+        <canvas id="healing-chart" class="chart-canvas mx-auto" width="800" height="300"></canvas>
+
+        <!-- Stats -->
+        <div class="grid grid-cols-2 gap-2 mt-3 max-w-md mx-auto">
+            <div class="stat-card">
+                <div class="stat-label">Mean Healing</div>
+                <div id="mean-healing" class="stat-value">-</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-label">Fix Value (F)</div>
+                <div id="fix-value" class="stat-value">-</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Row 4: Mathematics Section -->
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border border-gray-200 dark:border-gray-700 mb-6">
+        <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Mathematics</h2>
+
+        <h3 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">Fix Values</h3>
+        <p class="text-gray-600 dark:text-gray-400 mb-4">Fix values are determined by the following:</p>
+        <ul class="list-disc list-inside text-gray-600 dark:text-gray-400 mb-4 space-y-1">
+            <li>The amount of health units (Hf) of the fixing unit.</li>
+            <li>The fix (F) value of the fixing unit.</li>
+        </ul>
+
+        <h3 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">Formula</h3>
+        <div class="font-mono bg-gray-100 dark:bg-gray-700 p-4 rounded-lg mb-4 text-gray-800 dark:text-gray-200">
+            <p>p = 0.05 * F</p>
+            <p>if p &lt; 0, set p to 0</p>
+            <p>if p &gt; 1, set p to 1</p>
+        </div>
+        <p class="text-gray-600 dark:text-gray-400 mb-4">
+            For each health unit (Hf) of the fixing unit, three random numbers (r) between 0 and 1 are generated.
+            Each time r &lt; p, a fix is counted. The number of fixes divided by 3 is the number of health units the injured unit gains from the fix.
+        </p>
+
+        <h3 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">Notes</h3>
+        <ul class="list-disc list-inside text-gray-600 dark:text-gray-400 space-y-1">
+            <li>Fixing has a wider range of possible outcomes compared to attacks, making it less predictable.</li>
+        </ul>
+    </div>
+
+    <!-- Simulation Controls -->
+    <div class="mt-6 bg-white dark:bg-gray-800 rounded-lg shadow p-4 border border-gray-200 dark:border-gray-700">
+        <div class="flex items-center justify-between">
+            <div class="flex items-center space-x-4">
+                <label for="num-simulations" class="form-label mb-0">Number of Simulations:</label>
+                <input type="number" id="num-simulations" min="100" max="10000" value="{{.NumSimulations}}" step="100" class="form-input w-32">
+            </div>
+            <button id="simulate-btn" class="px-6 py-2 bg-green-600 hover:bg-green-700 text-white font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800">
+                Simulate Fix
+            </button>
+        </div>
+    </div>
+</main>
+{{ end }}
+
+{{ define "PostBodySection" }}
+<!-- Webpack-generated JavaScript bundle -->
+<script src="/static/wasm/wasm_exec.js"></script>
+{{# include "gen/FixSimulatorPage.html" #}}
+{{ end }}
+
+{{ define "FixSimulatorPage" }}
+{{ template "BasePage" . }}
+{{ end }}

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -31,6 +31,7 @@ const components = [
   ["GameViewerPage/index_Grid", 0, "ts"],
   ["GameViewerPage/index_Mobile", 0, "ts"],
   ["AttackSimulatorPage", 0, "ts"],
+  ["FixSimulatorPage", 0, "ts"],
 ];
 
 module.exports = (_env, options) => {


### PR DESCRIPTION
- Add fix simulation logic to lib/combat_formula.go with FixContext, CalculateFixProbability, SimulateFixHealing, and GenerateFixDistribution
- Add SimulateFix RPC to proto definitions (games_service.proto and games.proto)
- Implement SimulateFix method in services/games_service.go
- Create FixSimulatorPage Go handler, HTML template, and TypeScript
- Register route at /rules/fixsim and add webpack entry
- Add SimulateFix to public methods (no auth required)

The fix formula: p = 0.05 * F where F is the fix value. For each health unit of the fixing unit, 3 random rolls are made. Health restored = (successful rolls) / 3.