### PR TITLE
Fix dropdown option styling in dark mode for simulator pages

### DIFF
--- a/web/templates/AttackSimulatorPage.html
+++ b/web/templates/AttackSimulatorPage.html
@@ -47,6 +47,11 @@
         color: #f9fafb;
     }
 
+    .dark .form-select option {
+        background-color: #374151;
+        color: #f9fafb;
+    }
+
     .form-input {
         display: block;
         width: 100%;

--- a/web/templates/FixSimulatorPage.html
+++ b/web/templates/FixSimulatorPage.html
@@ -47,6 +47,11 @@
         color: #f9fafb;
     }
 
+    .dark .form-select option {
+        background-color: #374151;
+        color: #f9fafb;
+    }
+
     .form-input {
         display: block;
         width: 100%;


### PR DESCRIPTION
Add CSS styling for option elements inside form-select dropdowns so they have the correct dark background and light text when dark mode is active.