### PR TITLE
Refactor login command to use profiles

### DIFF
--- a/cmd/cli/cmd/login.go
+++ b/cmd/cli/cmd/login.go
@@ -14,125 +14,239 @@ import (
 )
 
 var (
-	loginToken string // For --token flag
+	loginHost     string
+	loginEmail    string
+	loginPassword string
+	loginToken    string
+	loginReset    bool
 )
 
 // loginCmd represents the login command
 var loginCmd = &cobra.Command{
-	Use:   "login <server>",
-	Short: "Authenticate to a LilBattle server",
-	Long: `Authenticate to a LilBattle server and store credentials locally.
+	Use:   "login <profile>",
+	Short: "Authenticate to a LilBattle server using a named profile",
+	Long: `Create or update a named profile and authenticate to a LilBattle server.
 
-The server URL should be the base URL of the server (e.g., http://localhost:8080).
+A profile stores your server URL, email, and credentials for easy switching
+between different servers or accounts.
+
+Missing required fields (host, email, password) will be prompted for.
+If a profile already exists, only provided flags will update existing values.
 
 Authentication methods:
-  - Interactive: Prompts for email and password
+  - Interactive: Prompts for password (hidden input)
   - Token: Use --token flag to provide a pre-generated API token
 
-Credentials are stored in ~/.config/lilbattle/credentials.json with
-restricted permissions (readable only by owner).
-
 Examples:
-  ww login http://localhost:8080
-  ww login https://lilbattle.example.com
-  ww login http://localhost:8080 --token eyJhbGc...`,
+  ww login prod --host https://lilbattle.com --email user@example.com
+  ww login local --host http://localhost:8080
+  ww login prod --token eyJhbGc...
+  ww login prod --reset                    # Force re-authentication
+
+After login, use 'ww select <profile>' to set it as the active profile.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runLogin,
 }
 
 func init() {
 	rootCmd.AddCommand(loginCmd)
-	loginCmd.Flags().StringVar(&loginToken, "token", "", "API token (skip interactive login)")
+	loginCmd.Flags().StringVar(&loginHost, "host", "", "server URL (e.g., https://lilbattle.com)")
+	loginCmd.Flags().StringVar(&loginEmail, "email", "", "email address for authentication")
+	loginCmd.Flags().StringVar(&loginPassword, "password", "", "password (will prompt if not provided)")
+	loginCmd.Flags().StringVar(&loginToken, "token", "", "API token (skip password authentication)")
+	loginCmd.Flags().BoolVar(&loginReset, "reset", false, "force re-authentication even if valid credentials exist")
 }
 
 func runLogin(cmd *cobra.Command, args []string) error {
-	serverURL := args[0]
+	profileNameArg := args[0]
 
-	// Normalize server URL
-	baseURL, err := extractServerBase(serverURL)
+	store, err := getProfileStore()
 	if err != nil {
-		return fmt.Errorf("invalid server URL: %w", err)
+		return fmt.Errorf("failed to initialize profile store: %w", err)
 	}
 
 	formatter := NewOutputFormatter()
+	reader := bufio.NewReader(os.Stdin)
 
-	// Get credential store
-	store, err := getCredentialStore()
-	if err != nil {
-		return fmt.Errorf("failed to load credentials: %w", err)
+	// Load existing profile if it exists
+	existingProfile, _ := store.LoadProfile(profileNameArg)
+	existingCreds, _ := store.LoadCredentials(profileNameArg)
+
+	// Build profile from existing + flags
+	profile := &Profile{Name: profileNameArg}
+	if existingProfile != nil {
+		profile = existingProfile
 	}
 
-	// Check if already logged in
-	existingCred, _ := store.GetCredential(baseURL)
-	if existingCred != nil && !existingCred.IsExpired() {
+	// Override with provided flags
+	if loginHost != "" {
+		profile.Host = loginHost
+	}
+	if loginEmail != "" {
+		profile.Email = loginEmail
+	}
+	if loginPassword != "" {
+		profile.Password = loginPassword
+	}
+
+	// Prompt for missing required fields
+	if profile.Host == "" {
+		fmt.Print("Host URL: ")
+		host, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("failed to read host: %w", err)
+		}
+		profile.Host = strings.TrimSpace(host)
+	}
+
+	// Normalize host URL
+	baseURL, err := extractServerBase(profile.Host)
+	if err != nil {
+		return fmt.Errorf("invalid host URL: %w", err)
+	}
+	profile.Host = baseURL
+
+	// Check if we need to authenticate
+	needsAuth := loginReset || loginToken != "" || existingCreds == nil || existingCreds.IsExpired()
+
+	// If not forcing auth and have valid credentials, just update profile
+	if !needsAuth && existingCreds != nil && !existingCreds.IsExpired() {
 		if !formatter.JSON {
-			fmt.Printf("Already logged in to %s as %s\n", baseURL, existingCred.UserEmail)
+			fmt.Printf("Profile '%s' already has valid credentials.\n", profileNameArg)
 			fmt.Print("Do you want to re-authenticate? [y/N]: ")
-			reader := bufio.NewReader(os.Stdin)
 			response, _ := reader.ReadString('\n')
 			response = strings.TrimSpace(strings.ToLower(response))
 			if response != "y" && response != "yes" {
+				// Just save any profile updates
+				if err := store.SaveProfile(profile); err != nil {
+					return fmt.Errorf("failed to save profile: %w", err)
+				}
+				fmt.Println("Profile updated.")
 				return nil
 			}
 		}
+		needsAuth = true
 	}
 
-	var cred *client.ServerCredential
+	var creds *ProfileCredentials
 
 	if loginToken != "" {
-		// Token-based login - store directly
-		cred = &client.ServerCredential{
+		// Token-based login
+		creds = &ProfileCredentials{
 			AccessToken: loginToken,
 			UserEmail:   "token-auth",
 			ExpiresAt:   time.Now().Add(30 * 24 * time.Hour),
 			CreatedAt:   time.Now(),
 		}
-		if err := store.SetCredential(baseURL, cred); err != nil {
-			return fmt.Errorf("failed to store credential: %w", err)
-		}
-		if err := store.Save(); err != nil {
-			return fmt.Errorf("failed to save credentials: %w", err)
-		}
 	} else {
-		// Interactive login using AuthClient
-		authClient := client.NewAuthClient(baseURL, store)
-
-		reader := bufio.NewReader(os.Stdin)
-
-		// Prompt for email
-		fmt.Print("Email: ")
-		email, err := reader.ReadString('\n')
-		if err != nil {
-			return fmt.Errorf("failed to read email: %w", err)
+		// Interactive login - need email and password
+		if profile.Email == "" {
+			fmt.Print("Email: ")
+			email, err := reader.ReadString('\n')
+			if err != nil {
+				return fmt.Errorf("failed to read email: %w", err)
+			}
+			profile.Email = strings.TrimSpace(email)
 		}
-		email = strings.TrimSpace(email)
 
-		// Prompt for password (hidden)
-		fmt.Print("Password: ")
-		passwordBytes, err := term.ReadPassword(int(syscall.Stdin))
-		fmt.Println() // Add newline after password input
-		if err != nil {
-			return fmt.Errorf("failed to read password: %w", err)
-		}
-		password := string(passwordBytes)
+		// Get password - check profile first, then prompt
+		password := profile.Password
+		if password == "" {
+			fmt.Print("Password: ")
+			passwordBytes, err := term.ReadPassword(int(syscall.Stdin))
+			fmt.Println()
+			if err != nil {
+				return fmt.Errorf("failed to read password: %w", err)
+			}
+			password = string(passwordBytes)
 
-		// Login via AuthClient
-		cred, err = authClient.Login(email, password, "read write profile offline")
-		if err != nil {
-			return err
+			// Ask if they want to save the password
+			if !formatter.JSON {
+				fmt.Print("Save password to profile? [y/N]: ")
+				response, _ := reader.ReadString('\n')
+				response = strings.TrimSpace(strings.ToLower(response))
+				if response == "y" || response == "yes" {
+					profile.Password = password
+				}
+			}
 		}
+
+		// Create a temporary credential store for the auth client
+		tempStore := &memCredStore{}
+		authClient := client.NewAuthClient(profile.Host, tempStore)
+
+		serverCred, err := authClient.Login(profile.Email, password, "read write profile offline")
+		if err != nil {
+			return fmt.Errorf("authentication failed: %w", err)
+		}
+
+		creds = FromServerCredential(serverCred)
+	}
+
+	// Save profile and credentials
+	if err := store.SaveProfile(profile); err != nil {
+		return fmt.Errorf("failed to save profile: %w", err)
+	}
+
+	if err := store.SaveCredentials(profileNameArg, creds); err != nil {
+		return fmt.Errorf("failed to save credentials: %w", err)
 	}
 
 	if formatter.JSON {
 		return formatter.PrintJSON(map[string]any{
-			"server":     baseURL,
-			"user_id":    cred.UserID,
-			"user_email": cred.UserEmail,
-			"expires_at": cred.ExpiresAt,
+			"profile":    profileNameArg,
+			"host":       profile.Host,
+			"email":      profile.Email,
+			"user_id":    creds.UserID,
+			"user_email": creds.UserEmail,
+			"expires_at": creds.ExpiresAt,
 		})
 	}
 
-	fmt.Printf("Successfully logged in to %s as %s\n", baseURL, cred.UserEmail)
-	fmt.Printf("Token expires: %s\n", cred.ExpiresAt.Format(time.RFC3339))
+	fmt.Printf("Successfully logged in to profile '%s'\n", profileNameArg)
+	fmt.Printf("  Host: %s\n", profile.Host)
+	fmt.Printf("  Email: %s\n", creds.UserEmail)
+	fmt.Printf("  Expires: %s\n", creds.ExpiresAt.Format(time.RFC3339))
+	fmt.Printf("\nUse 'ww select %s' to set this as your active profile.\n", profileNameArg)
+
+	return nil
+}
+
+// memCredStore is a minimal in-memory credential store for the auth client
+type memCredStore struct {
+	creds map[string]*client.ServerCredential
+}
+
+func (s *memCredStore) GetCredential(serverURL string) (*client.ServerCredential, error) {
+	if s.creds == nil {
+		return nil, nil
+	}
+	return s.creds[serverURL], nil
+}
+
+func (s *memCredStore) SetCredential(serverURL string, cred *client.ServerCredential) error {
+	if s.creds == nil {
+		s.creds = make(map[string]*client.ServerCredential)
+	}
+	s.creds[serverURL] = cred
+	return nil
+}
+
+func (s *memCredStore) RemoveCredential(serverURL string) error {
+	if s.creds != nil {
+		delete(s.creds, serverURL)
+	}
+	return nil
+}
+
+func (s *memCredStore) ListServers() ([]string, error) {
+	servers := make([]string, 0, len(s.creds))
+	for k := range s.creds {
+		servers = append(servers, k)
+	}
+	return servers, nil
+}
+
+func (s *memCredStore) Save() error {
 	return nil
 }

--- a/cmd/cli/cmd/profile_cmd.go
+++ b/cmd/cli/cmd/profile_cmd.go
@@ -1,0 +1,202 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// profileCmd represents the profile parent command
+var profileCmd = &cobra.Command{
+	Use:   "profile",
+	Short: "Manage profiles",
+	Long: `Manage authentication profiles.
+
+Subcommands:
+  show    Show details of a profile
+  delete  Delete a profile`,
+}
+
+// profileShowCmd represents the profile show command
+var profileShowCmd = &cobra.Command{
+	Use:   "show [profile]",
+	Short: "Show profile details",
+	Long: `Show detailed information about a profile.
+
+If no profile is specified, shows the current active profile.
+
+Examples:
+  ww profile show prod     # Show details of 'prod' profile
+  ww profile show          # Show current profile details`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runProfileShow,
+}
+
+// profileDeleteCmd represents the profile delete command
+var profileDeleteCmd = &cobra.Command{
+	Use:   "delete <profile>",
+	Short: "Delete a profile",
+	Long: `Delete a profile and all its stored credentials.
+
+This will prompt for confirmation unless --confirm=false is set.
+
+Examples:
+  ww profile delete prod              # Delete 'prod' profile (prompts)
+  ww profile delete prod --confirm=false  # Delete without prompting`,
+	Args: cobra.ExactArgs(1),
+	RunE: runProfileDelete,
+}
+
+func init() {
+	rootCmd.AddCommand(profileCmd)
+	profileCmd.AddCommand(profileShowCmd)
+	profileCmd.AddCommand(profileDeleteCmd)
+}
+
+func runProfileShow(cmd *cobra.Command, args []string) error {
+	store, err := getProfileStore()
+	if err != nil {
+		return fmt.Errorf("failed to initialize profile store: %w", err)
+	}
+
+	formatter := NewOutputFormatter()
+
+	var profileNameArg string
+	if len(args) > 0 {
+		profileNameArg = args[0]
+	} else {
+		// Use current profile
+		profileNameArg, err = store.GetCurrentProfile()
+		if err != nil {
+			return fmt.Errorf("failed to get current profile: %w", err)
+		}
+		if profileNameArg == "" {
+			if formatter.JSON {
+				return formatter.PrintJSON(map[string]any{
+					"error": "no profile selected",
+				})
+			}
+			fmt.Println("No profile selected.")
+			fmt.Println("Use 'ww profile show <profile>' or 'ww select <profile>' first.")
+			return nil
+		}
+	}
+
+	profile, err := store.LoadProfile(profileNameArg)
+	if err != nil {
+		return fmt.Errorf("profile '%s' does not exist", profileNameArg)
+	}
+
+	creds, _ := store.LoadCredentials(profileNameArg)
+	currentProfile, _ := store.GetCurrentProfile()
+
+	if formatter.JSON {
+		result := map[string]any{
+			"name":    profileNameArg,
+			"host":    profile.Host,
+			"email":   profile.Email,
+			"current": profileNameArg == currentProfile,
+		}
+
+		if profile.Password != "" {
+			result["password_saved"] = true
+		}
+
+		if creds != nil {
+			result["authenticated"] = !creds.IsExpired()
+			result["user_id"] = creds.UserID
+			result["user_email"] = creds.UserEmail
+			result["expires_at"] = creds.ExpiresAt
+			result["created_at"] = creds.CreatedAt
+		} else {
+			result["authenticated"] = false
+		}
+
+		return formatter.PrintJSON(result)
+	}
+
+	fmt.Printf("Profile: %s", profileNameArg)
+	if profileNameArg == currentProfile {
+		fmt.Printf(" (current)")
+	}
+	fmt.Println()
+
+	fmt.Printf("  Host: %s\n", profile.Host)
+	if profile.Email != "" {
+		fmt.Printf("  Email: %s\n", profile.Email)
+	}
+	if profile.Password != "" {
+		fmt.Printf("  Password: saved\n")
+	}
+
+	if creds != nil {
+		fmt.Println()
+		fmt.Printf("  Authentication:\n")
+		if creds.UserID != "" {
+			fmt.Printf("    User ID: %s\n", creds.UserID)
+		}
+		if creds.UserEmail != "" {
+			fmt.Printf("    User Email: %s\n", creds.UserEmail)
+		}
+
+		if creds.IsExpired() {
+			fmt.Printf("    Status: EXPIRED (expired %s ago)\n", time.Since(creds.ExpiresAt).Round(time.Minute))
+		} else {
+			remaining := time.Until(creds.ExpiresAt)
+			fmt.Printf("    Status: Valid (expires in %s)\n", remaining.Round(time.Minute))
+		}
+		fmt.Printf("    Created: %s\n", creds.CreatedAt.Format(time.RFC3339))
+	} else {
+		fmt.Println()
+		fmt.Printf("  Authentication: not authenticated\n")
+	}
+
+	return nil
+}
+
+func runProfileDelete(cmd *cobra.Command, args []string) error {
+	profileNameArg := args[0]
+
+	store, err := getProfileStore()
+	if err != nil {
+		return fmt.Errorf("failed to initialize profile store: %w", err)
+	}
+
+	formatter := NewOutputFormatter()
+
+	// Verify profile exists
+	_, err = store.LoadProfile(profileNameArg)
+	if err != nil {
+		return fmt.Errorf("profile '%s' does not exist", profileNameArg)
+	}
+
+	// Confirm deletion
+	if shouldConfirm() && !formatter.JSON {
+		fmt.Printf("Delete profile '%s' and all its credentials? [y/N]: ", profileNameArg)
+		reader := bufio.NewReader(os.Stdin)
+		response, _ := reader.ReadString('\n')
+		response = strings.TrimSpace(strings.ToLower(response))
+		if response != "y" && response != "yes" {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	}
+
+	if err := store.DeleteProfile(profileNameArg); err != nil {
+		return fmt.Errorf("failed to delete profile: %w", err)
+	}
+
+	if formatter.JSON {
+		return formatter.PrintJSON(map[string]any{
+			"profile": profileNameArg,
+			"deleted": true,
+		})
+	}
+
+	fmt.Printf("Profile '%s' deleted.\n", profileNameArg)
+	return nil
+}

--- a/cmd/cli/cmd/profiles.go
+++ b/cmd/cli/cmd/profiles.go
@@ -1,0 +1,335 @@
+// Package cmd provides CLI commands for lilbattle.
+// This file implements profile-based credential management.
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/panyam/oneauth/client"
+)
+
+// Profile represents a named configuration profile
+type Profile struct {
+	Name     string `json:"name"`
+	Host     string `json:"host"`
+	Email    string `json:"email,omitempty"`
+	Password string `json:"password,omitempty"` // Stored only for local FS profiles
+}
+
+// ProfileCredentials stores authentication tokens for a profile
+type ProfileCredentials struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	UserID       string    `json:"user_id,omitempty"`
+	UserEmail    string    `json:"user_email,omitempty"`
+	ExpiresAt    time.Time `json:"expires_at"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+// IsExpired checks if the credentials have expired
+func (c *ProfileCredentials) IsExpired() bool {
+	return time.Now().After(c.ExpiresAt)
+}
+
+// ToServerCredential converts to oneauth ServerCredential for API compatibility
+func (c *ProfileCredentials) ToServerCredential() *client.ServerCredential {
+	return &client.ServerCredential{
+		AccessToken:  c.AccessToken,
+		RefreshToken: c.RefreshToken,
+		UserID:       c.UserID,
+		UserEmail:    c.UserEmail,
+		ExpiresAt:    c.ExpiresAt,
+		CreatedAt:    c.CreatedAt,
+	}
+}
+
+// FromServerCredential creates ProfileCredentials from oneauth ServerCredential
+func FromServerCredential(cred *client.ServerCredential) *ProfileCredentials {
+	return &ProfileCredentials{
+		AccessToken:  cred.AccessToken,
+		RefreshToken: cred.RefreshToken,
+		UserID:       cred.UserID,
+		UserEmail:    cred.UserEmail,
+		ExpiresAt:    cred.ExpiresAt,
+		CreatedAt:    cred.CreatedAt,
+	}
+}
+
+// GlobalConfig stores global CLI configuration
+type GlobalConfig struct {
+	CurrentProfile string `json:"current_profile,omitempty"`
+}
+
+// ProfileStore manages profile storage
+type ProfileStore struct {
+	baseDir string
+}
+
+// Global profile store instance
+var profileStore *ProfileStore
+
+// getProfileStore returns the singleton profile store
+func getProfileStore() (*ProfileStore, error) {
+	if profileStore == nil {
+		configDir, err := os.UserConfigDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get config directory: %w", err)
+		}
+		baseDir := filepath.Join(configDir, "lilbattle")
+		profileStore = &ProfileStore{baseDir: baseDir}
+	}
+	return profileStore, nil
+}
+
+// ensureDir creates a directory if it doesn't exist
+func ensureDir(path string) error {
+	return os.MkdirAll(path, 0700)
+}
+
+// profileDir returns the directory for a specific profile
+func (s *ProfileStore) profileDir(name string) string {
+	return filepath.Join(s.baseDir, "profiles", name)
+}
+
+// profilePath returns the path to the profile.json file
+func (s *ProfileStore) profilePath(name string) string {
+	return filepath.Join(s.profileDir(name), "profile.json")
+}
+
+// credentialsPath returns the path to the credentials.json file
+func (s *ProfileStore) credentialsPath(name string) string {
+	return filepath.Join(s.profileDir(name), "credentials.json")
+}
+
+// configPath returns the path to the global config file
+func (s *ProfileStore) configPath() string {
+	return filepath.Join(s.baseDir, "config.json")
+}
+
+// LoadGlobalConfig loads the global configuration
+func (s *ProfileStore) LoadGlobalConfig() (*GlobalConfig, error) {
+	data, err := os.ReadFile(s.configPath())
+	if os.IsNotExist(err) {
+		return &GlobalConfig{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var config GlobalConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+// SaveGlobalConfig saves the global configuration
+func (s *ProfileStore) SaveGlobalConfig(config *GlobalConfig) error {
+	if err := ensureDir(s.baseDir); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.configPath(), data, 0600)
+}
+
+// GetCurrentProfile returns the name of the currently selected profile
+func (s *ProfileStore) GetCurrentProfile() (string, error) {
+	config, err := s.LoadGlobalConfig()
+	if err != nil {
+		return "", err
+	}
+	return config.CurrentProfile, nil
+}
+
+// SetCurrentProfile sets the currently selected profile
+func (s *ProfileStore) SetCurrentProfile(name string) error {
+	// Verify profile exists
+	if _, err := s.LoadProfile(name); err != nil {
+		return fmt.Errorf("profile '%s' does not exist", name)
+	}
+
+	config, err := s.LoadGlobalConfig()
+	if err != nil {
+		return err
+	}
+	config.CurrentProfile = name
+	return s.SaveGlobalConfig(config)
+}
+
+// ListProfiles returns all profile names
+func (s *ProfileStore) ListProfiles() ([]string, error) {
+	profilesDir := filepath.Join(s.baseDir, "profiles")
+	entries, err := os.ReadDir(profilesDir)
+	if os.IsNotExist(err) {
+		return []string{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var profiles []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			// Check if profile.json exists
+			profilePath := filepath.Join(profilesDir, entry.Name(), "profile.json")
+			if _, err := os.Stat(profilePath); err == nil {
+				profiles = append(profiles, entry.Name())
+			}
+		}
+	}
+	return profiles, nil
+}
+
+// LoadProfile loads a profile by name
+func (s *ProfileStore) LoadProfile(name string) (*Profile, error) {
+	data, err := os.ReadFile(s.profilePath(name))
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("profile '%s' does not exist", name)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var profile Profile
+	if err := json.Unmarshal(data, &profile); err != nil {
+		return nil, err
+	}
+	profile.Name = name // Ensure name matches directory
+	return &profile, nil
+}
+
+// SaveProfile saves a profile
+func (s *ProfileStore) SaveProfile(profile *Profile) error {
+	dir := s.profileDir(profile.Name)
+	if err := ensureDir(dir); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(profile, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.profilePath(profile.Name), data, 0600)
+}
+
+// LoadCredentials loads credentials for a profile
+func (s *ProfileStore) LoadCredentials(name string) (*ProfileCredentials, error) {
+	data, err := os.ReadFile(s.credentialsPath(name))
+	if os.IsNotExist(err) {
+		return nil, nil // No credentials yet
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var creds ProfileCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, err
+	}
+	return &creds, nil
+}
+
+// SaveCredentials saves credentials for a profile
+func (s *ProfileStore) SaveCredentials(name string, creds *ProfileCredentials) error {
+	dir := s.profileDir(name)
+	if err := ensureDir(dir); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.credentialsPath(name), data, 0600)
+}
+
+// DeleteProfile removes a profile and all its data
+func (s *ProfileStore) DeleteProfile(name string) error {
+	dir := s.profileDir(name)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return fmt.Errorf("profile '%s' does not exist", name)
+	}
+
+	// Clear current profile if it's being deleted
+	config, _ := s.LoadGlobalConfig()
+	if config != nil && config.CurrentProfile == name {
+		config.CurrentProfile = ""
+		s.SaveGlobalConfig(config)
+	}
+
+	return os.RemoveAll(dir)
+}
+
+// GetActiveProfile returns the active profile based on precedence:
+// 1. --profile flag
+// 2. Current selected profile
+func GetActiveProfile(profileFlag string) (*Profile, error) {
+	store, err := getProfileStore()
+	if err != nil {
+		return nil, err
+	}
+
+	var profileName string
+
+	if profileFlag != "" {
+		profileName = profileFlag
+	} else {
+		profileName, err = store.GetCurrentProfile()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if profileName == "" {
+		return nil, nil // No profile active
+	}
+
+	return store.LoadProfile(profileName)
+}
+
+// GetActiveCredentials returns credentials for the active profile
+func GetActiveCredentials(profileFlag string) (*ProfileCredentials, error) {
+	store, err := getProfileStore()
+	if err != nil {
+		return nil, err
+	}
+
+	var profileName string
+
+	if profileFlag != "" {
+		profileName = profileFlag
+	} else {
+		profileName, err = store.GetCurrentProfile()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if profileName == "" {
+		return nil, nil
+	}
+
+	return store.LoadCredentials(profileName)
+}
+
+// GetTokenForProfile returns the access token for a profile, or empty if not found/expired
+func GetTokenForProfile(profileFlag string) string {
+	creds, err := GetActiveCredentials(profileFlag)
+	if err != nil || creds == nil {
+		return ""
+	}
+
+	if creds.IsExpired() {
+		return ""
+	}
+
+	return creds.AccessToken
+}

--- a/cmd/cli/cmd/profiles_cmd.go
+++ b/cmd/cli/cmd/profiles_cmd.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// profilesCmd represents the profiles command
+var profilesCmd = &cobra.Command{
+	Use:   "profiles",
+	Short: "List all configured profiles",
+	Long: `List all configured profiles with their authentication status.
+
+The current active profile is marked with an asterisk (*).
+
+Examples:
+  ww profiles              # List all profiles
+  ww profiles --json       # Output as JSON`,
+	RunE: runProfiles,
+}
+
+func init() {
+	rootCmd.AddCommand(profilesCmd)
+}
+
+func runProfiles(cmd *cobra.Command, args []string) error {
+	store, err := getProfileStore()
+	if err != nil {
+		return fmt.Errorf("failed to initialize profile store: %w", err)
+	}
+
+	formatter := NewOutputFormatter()
+
+	profiles, err := store.ListProfiles()
+	if err != nil {
+		return fmt.Errorf("failed to list profiles: %w", err)
+	}
+
+	currentProfile, _ := store.GetCurrentProfile()
+
+	if len(profiles) == 0 {
+		if formatter.JSON {
+			return formatter.PrintJSON(map[string]any{
+				"profiles":        []any{},
+				"current_profile": "",
+			})
+		}
+		fmt.Println("No profiles configured.")
+		fmt.Println("Use 'ww login <profile> --host <url>' to create a profile.")
+		return nil
+	}
+
+	if formatter.JSON {
+		profileList := make([]map[string]any, 0, len(profiles))
+		for _, name := range profiles {
+			profile, _ := store.LoadProfile(name)
+			creds, _ := store.LoadCredentials(name)
+
+			entry := map[string]any{
+				"name":    name,
+				"current": name == currentProfile,
+			}
+
+			if profile != nil {
+				entry["host"] = profile.Host
+				entry["email"] = profile.Email
+			}
+
+			if creds != nil {
+				entry["authenticated"] = !creds.IsExpired()
+				entry["expires_at"] = creds.ExpiresAt
+			} else {
+				entry["authenticated"] = false
+			}
+
+			profileList = append(profileList, entry)
+		}
+		return formatter.PrintJSON(map[string]any{
+			"profiles":        profileList,
+			"current_profile": currentProfile,
+		})
+	}
+
+	fmt.Println("Configured profiles:")
+	for _, name := range profiles {
+		profile, _ := store.LoadProfile(name)
+		creds, _ := store.LoadCredentials(name)
+
+		marker := "  "
+		if name == currentProfile {
+			marker = "* "
+		}
+
+		status := "no credentials"
+		if creds != nil {
+			if creds.IsExpired() {
+				status = "expired"
+			} else {
+				remaining := time.Until(creds.ExpiresAt)
+				if remaining < 24*time.Hour {
+					status = fmt.Sprintf("expires in %s", remaining.Round(time.Minute))
+				} else {
+					status = "valid"
+				}
+			}
+		}
+
+		host := "not set"
+		if profile != nil && profile.Host != "" {
+			host = profile.Host
+		}
+
+		fmt.Printf("%s%s\n", marker, name)
+		fmt.Printf("    Host: %s\n", host)
+		fmt.Printf("    Status: %s\n", status)
+	}
+
+	if currentProfile != "" {
+		fmt.Printf("\n* = current profile\n")
+	} else {
+		fmt.Printf("\nNo profile selected. Use 'ww select <profile>' to set one.\n")
+	}
+
+	return nil
+}

--- a/cmd/cli/cmd/select.go
+++ b/cmd/cli/cmd/select.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// selectCmd represents the select command
+var selectCmd = &cobra.Command{
+	Use:   "select <profile>",
+	Short: "Set the active profile for subsequent commands",
+	Long: `Set a profile as the active profile for all subsequent CLI commands.
+
+The active profile's host and credentials will be used automatically
+unless overridden by --server, --profile flags, or LILBATTLE_SERVER env var.
+
+Examples:
+  ww select prod           # Set 'prod' as the active profile
+  ww select local-dev      # Switch to local development profile
+
+Use 'ww profiles' to list all available profiles.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSelect,
+}
+
+func init() {
+	rootCmd.AddCommand(selectCmd)
+}
+
+func runSelect(cmd *cobra.Command, args []string) error {
+	profileNameArg := args[0]
+
+	store, err := getProfileStore()
+	if err != nil {
+		return fmt.Errorf("failed to initialize profile store: %w", err)
+	}
+
+	formatter := NewOutputFormatter()
+
+	// Verify profile exists
+	profile, err := store.LoadProfile(profileNameArg)
+	if err != nil {
+		return fmt.Errorf("profile '%s' does not exist. Use 'ww login %s' to create it", profileNameArg, profileNameArg)
+	}
+
+	// Set as current profile
+	if err := store.SetCurrentProfile(profileNameArg); err != nil {
+		return fmt.Errorf("failed to set current profile: %w", err)
+	}
+
+	if formatter.JSON {
+		return formatter.PrintJSON(map[string]any{
+			"profile":  profileNameArg,
+			"host":     profile.Host,
+			"email":    profile.Email,
+			"selected": true,
+		})
+	}
+
+	fmt.Printf("Switched to profile '%s'\n", profileNameArg)
+	fmt.Printf("  Host: %s\n", profile.Host)
+	if profile.Email != "" {
+		fmt.Printf("  Email: %s\n", profile.Email)
+	}
+
+	return nil
+}

--- a/cmd/cli/cmd/utils.go
+++ b/cmd/cli/cmd/utils.go
@@ -36,12 +36,19 @@ func GetGameContext() (*GameContext, error) {
 	var svc services.GamesService
 	var isRemote bool
 	if serverURL != "" {
-		// Get auth token for this server
-		token := GetTokenForServer(serverURL)
+		// Get auth token from profile
+		token := GetTokenForProfile(getProfileName())
 		svc = connectclient.NewConnectGamesClientWithAuth(serverURL, token)
 		isRemote = true
 		if isVerbose() {
-			fmt.Printf("[VERBOSE] Connecting to server: %s (auth: %v)\n", serverURL, token != "")
+			profileName := getProfileName()
+			if profileName == "" {
+				store, _ := getProfileStore()
+				if store != nil {
+					profileName, _ = store.GetCurrentProfile()
+				}
+			}
+			fmt.Printf("[VERBOSE] Connecting to server: %s (profile: %s, auth: %v)\n", serverURL, profileName, token != "")
 		}
 	} else {
 		svc = fsbe.NewFSGamesService("", nil)


### PR DESCRIPTION
This replaces the server-URL-based credential storage with a profile-based system allowing multiple accounts per host and easy environment switching.

New commands:
- ww login <profile> [--host] [--email] [--password] [--token] [--reset]
- ww select <profile> - set active profile
- ww profiles - list all profiles
- ww profile show/delete - manage profiles

Changes:
- Add --profile global flag for command overrides
- Update getServerURL() to use profile host as fallback
- Profile storage in ~/.config/lilbattle/profiles/<name>/
- Each profile stores: profile.json (host, email, password) and credentials.json (token, expiry)
- Update whoami/logout to work with profiles
- Maintain backward compatibility with legacy credentials for migrate command

Precedence order: --server flag > LILBATTLE_SERVER env > profile host