### PR TITLE
Expand CI test coverage; bump Go workflow version to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
       - uses: pnpm/action-setup@v4
         with:
           version: 10
@@ -36,7 +36,7 @@ jobs:
         run: go build $(go list ./... | grep -v -E 'cmd/(wasm|repl|indexer)|tests/')
 
       - name: Go tests
-        run: go test ./tests/... ./cmd/cli/... ./services/r2/... ./web/assets/themes/...
+        run: go test ./tests/... ./cmd/cli/... ./lib/... ./services/authz/... ./services/r2/... ./web/server/... ./web/assets/themes/...
 
       - name: Frontend build
         run: cd web && pnpm install --frozen-lockfile && pnpm run buildprod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
       - uses: pnpm/action-setup@v4
         with:
           version: 10

--- a/LAUNCH_READINESS_AUDIT.md
+++ b/LAUNCH_READINESS_AUDIT.md
@@ -458,11 +458,15 @@ Areas where the game logic needs combinatorial testing across unit types, terrai
    ✅ they were fixed in the same PR that added the audit (PR 109
    squashed three commits; audit text drafted before the fix
    commit). Permanent — re-verified June 2026.
-2. **Add `lib/` tests to CI** — unblocked; safe to land.
-3. **Add TS tests to CI** (`cd web && pnpm test`)
-4. **Add `services/authz/` and `web/server/` tests to CI**
-5. **Victory condition tests** — a game without verified win conditions is incomplete
-6. **Fix damage estimate** — still hardcoded at 50 in `lib/game.go:755` (audit said `game.go` — actual location is `lib/game.go`)
+2. ~~**Add `lib/` tests to CI**~~ — landed in issue 119 (June 2026).
+3. **Add TS tests to CI** (`cd web && pnpm test`) — deferred from
+   issue 119 because the jest setup is broken at three layers (config
+   roots, test imports, pre-WASM-Phase-13 architecture). Tracked
+   separately at issue 149.
+4. ~~**Add `services/authz/` and `web/server/` tests to CI**~~ —
+   landed in issue 119 (June 2026).
+5. **Victory condition tests** — a game without verified win conditions is incomplete (tracked at issue 120)
+6. **Fix damage estimate** — still hardcoded at 50 in `lib/game.go:755` (tracked at issue 121)
 
 ### P1 — High Priority (Production Quality)
 
@@ -503,26 +507,21 @@ Areas where the game logic needs combinatorial testing across unit types, terrai
 
 ### 6.1 CI Coverage Gaps
 
-The current CI command:
+As of issue 119 (June 2026), the CI command covers:
 ```
-go test ./tests/... ./cmd/cli/... ./services/r2/... ./web/assets/themes/...
+go test ./tests/... ./cmd/cli/... ./lib/... ./services/authz/... ./services/r2/... ./web/server/... ./web/assets/themes/...
 ```
 
-**Misses**:
-- `./lib/...` (action sequence tests, rules loader)
-- `./services/authz/...`
-- `./web/server/...` (connect auth integration)
-- TypeScript unit tests (`web/tests/`)
+**Remaining gap**:
+- TypeScript unit tests (`web/tests/`) — deferred because the jest
+  setup is broken at three layers (config roots, test imports,
+  pre-WASM-Phase-13 architecture); tracked at issue 149.
 
-Proposed CI test command:
+Once issue 149 lands, the target CI command becomes:
 ```
 go test ./tests/... ./cmd/cli/... ./lib/... ./services/authz/... ./services/r2/... ./web/server/... ./web/assets/themes/...
 cd web && pnpm test
 ```
-
-Note: As of June 2026, the proposed command above passes locally
-(417 runs, all green). The Feb-era caveat that `./lib/...` would break
-CI no longer applies.
 
 ### 6.2 Test Coverage Reporting
 


### PR DESCRIPTION
Closes issue 119 (audit P0 items 2 and 4).

## What changes

CI's Go test command was running ~330 tests; now runs 417 by adding the four packages that already pass locally but weren't in the signal: `./lib/...`, `./services/authz/...`, `./web/server/...`, and (already present) `./services/r2/...`. Risk-free expansion — these are existing green tests, just now wired up to fail CI when they break.

Bonus: Go workflow version bumped 1.24 → 1.26 to match `go.mod`'s 1.26.4 requirement (set by the oneauth v0.1.29 bump in PR 118). The toolchain directive was auto-downloading 1.26.4 on top of declared 1.24, which worked but emitted "Cannot open: File exists" warnings on every extraction.

## Reviewer's guide

Read in this order:

1. [.github/workflows/ci.yml](https://github.com/turnforge/lilbattle/pull/151/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) — start here. Two changes: `go-version` and the `Go tests` step's package list.
2. [.github/workflows/deploy.yml](https://github.com/turnforge/lilbattle/pull/151/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3) — same `go-version` bump, mirror change.
3. [LAUNCH_READINESS_AUDIT.md](https://github.com/turnforge/lilbattle/pull/151/files#diff-78acc021b8fb6b523b46b73d4ca23666655b7bc984910b05400578fee826c396) — §5 P0 items 2 and 4 marked done; §6.1 caveat removed (locally green is no longer hypothetical); §6.1 now points at issue 149 for the residual TS gap.

## Decision log

- **Deferred adding `pnpm test` to CI (audit P0 item 3).** The TS test setup is broken at three independent layers: jest.config.js `roots` references `<rootDir>/src` which doesn't exist (TS source moved to `web/pages/`); `web/tests/rulesEngine.test.ts:9` imports from a non-existent `../src/GameState`; and the test architecture predates the WASM-Centric GameState refactor (Phase 13 per docs/SUMMARY.md). Wiring `pnpm test` today would just paint CI red. Repair tracked at issue 149 (P0, testing).
- **Bumped Go to 1.26 rather than 1.26.4.** `go.mod` says 1.26.4 but the workflow only needs the major.minor for setup-go's version-resolution; pinning the patch would force a workflow edit on every Go patch release. setup-go honours the toolchain directive in go.mod for the exact patch version anyway.
- **Did not touch deploy.yml beyond the Go bump.** Deploy is currently failing for an unrelated reason (dangling `discord_tracking` symlink trips gcloud's source stat). Tracked at issue 150.

## Risk / blast radius

- Affects: CI workflow only. No production code touched.
- Tests covering this: the workflow itself — the PR is its own test, watch CI go green before merging.
- Be paranoid about: nothing major — if a package surprises me by failing on the Linux runner where it passes locally on darwin/arm64, easy revert.

## Out of scope (deliberately deferred)

- TS test repair → issue 149
- Deploy workflow symlink failure → issue 150
- All other audit P0/P1/P2/P3 items have their own issues (#119-148)

