### PR TITLE
Untrack discord_tracking symlink and ignore it in deploy

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -44,3 +44,6 @@ data/
 # Docker files
 docker-compose.yml
 db-docker-compose.yml
+
+# Local symlink to sibling discord-tracking repo; convenience only — not deployed.
+discord_tracking

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ storage
 # Templar lock file (machine-specific)
 web/templates/templar.lock
 .wrangler/
+
+# Local symlink to sibling discord-tracking repo; convenience only — not deployed.
+discord_tracking

--- a/discord_tracking
+++ b/discord_tracking
@@ -1,1 +1,0 @@
-../lilbattle-tracking


### PR DESCRIPTION
Closes issue 150.

## What changes

Untracks the `discord_tracking` symlink and adds it to both `.gitignore` and `.gcloudignore`. Local symlink stays on disk for maintainers who have the sibling repo; CI/Deploy stop seeing a tracked dangling-on-runner symlink.

## Reviewer's guide

Read in this order:

1. [.gitignore](https://github.com/turnforge/lilbattle/pull/152/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) — appended [discord_tracking](https://github.com/turnforge/lilbattle/pull/152/files#diff-35ff092856cddebaa3743b40bc66f7a81786e840d73274aad62818883cc5744d) with a short comment about its purpose. Discoverable for anyone wondering why a fresh clone is missing it.
2. [.gcloudignore](https://github.com/turnforge/lilbattle/pull/152/files#diff-3259bc6b4c7c0b2102edc43ea69503802e5ec63e56e40d5660cc5c7926a8285c) — same entry under existing structure. Belt-and-braces in case someone re-tracks the file locally.
3. [discord_tracking](https://github.com/turnforge/lilbattle/pull/152/files#diff-35ff092856cddebaa3743b40bc66f7a81786e840d73274aad62818883cc5744d) — deletion entry. `git rm --cached` removed the index entry only; the symlink remains on disk for maintainers who already had it.

## Decision log

- **Untrack vs `.gcloudignore`-only.** `.gcloudignore` alone would silence the Deploy failure but leave the dangling symlink in the index, so the smell persists for every fresh-clone CI run. Untracking removes the root cause; .gitignore prevents recurrence.
- **`.gitignore` matters even though the file's already tracked.** Once `git rm --cached` removes the index entry, .gitignore prevents the next `git add .` from re-adding it. Without that, the convenience symlink would re-enter the index whenever someone runs a broad add locally.
- **Maintainer convenience preserved via recreation, not via tracking.** Anyone wanting the symlink can `ln -s ../lilbattle-tracking discord_tracking` — discoverable from the .gitignore comment. The original "track it so clones get it automatically" intent was the bug that produced the Deploy break.

## Risk / blast radius

- Affects: CI Deploy workflow (should turn green), maintainer workstations that already have the symlink (unchanged — local file untouched), fresh clones (no longer auto-resolve the tracker).
- Tests covering this: PR's own Deploy run on merge to main. Sample CI run on this PR confirms no regression to test workflow.

## Out of scope

- The Deploy workflow has unrelated cleanup opportunities (Node 20 → 24 deprecation warning, manual secret injection patterns). Not touched here.

