### PR TITLE
Pin remaining victory-condition cases (closes 120)

### DIFF
--- a/tests/victory_conditions_test.go
+++ b/tests/victory_conditions_test.go
@@ -83,3 +83,152 @@ func TestVictoryConditions_NoWinner_BothActive(t *testing.T) {
 		t.Errorf("expected Status != ENDED while game in progress; got %v", got)
 	}
 }
+
+// TestVictoryConditions_TwoPlayer_LastStanding pins the baseline win path:
+// P2 has no units when P1 ends turn, so checkVictoryConditions detects
+// last-player-standing and the game ends with P1 as winner.
+func TestVictoryConditions_TwoPlayer_LastStanding(t *testing.T) {
+	setup := newVictoryTestGame(t, 2, []bool{true, false})
+
+	_, err := setup.Game.EndTurn()
+	if err != nil {
+		t.Fatalf("EndTurn failed: %v", err)
+	}
+
+	if !setup.Game.GameState.Finished {
+		t.Errorf("expected Finished=true after last-standing detected; got false")
+	}
+	if got := setup.Game.GameState.WinningPlayer; got != 1 {
+		t.Errorf("expected WinningPlayer=1; got %d", got)
+	}
+	if got := setup.Game.GameState.Status; got != v1.GameStatus_GAME_STATUS_ENDED {
+		t.Errorf("expected Status=ENDED; got %v", got)
+	}
+}
+
+// TestVictoryConditions_ThreePlayer_MidGameElim_NoWinner pins two behaviors
+// at once:
+//
+//  1. Multi-player elimination doesn't prematurely end the game — with P2
+//     out but P1 and P3 still active, EndTurn must not declare a winner.
+//  2. Eliminated players keep their turn slot in the current cycling impl —
+//     EndTurn from P1 advances CurrentPlayer to 2 (not 3), even though P2
+//     has nothing to act with. If this changes (e.g. skipping eliminated
+//     players), the test forces the behavior change to be deliberate.
+func TestVictoryConditions_ThreePlayer_MidGameElim_NoWinner(t *testing.T) {
+	setup := newVictoryTestGame(t, 3, []bool{true, false, true})
+
+	_, err := setup.Game.EndTurn()
+	if err != nil {
+		t.Fatalf("EndTurn failed: %v", err)
+	}
+
+	if setup.Game.GameState.Finished {
+		t.Errorf("expected Finished=false with 2 of 3 players still alive; got true")
+	}
+	if got := setup.Game.CurrentPlayer; got != 2 {
+		t.Errorf("expected CurrentPlayer=2 (eliminated players are not skipped in current impl); got %d", got)
+	}
+}
+
+// TestVictoryConditions_ThreePlayer_LastSurvivor_Wins pins multi-player
+// convergence: when only one of three players retains units, EndTurn
+// declares that player the winner.
+func TestVictoryConditions_ThreePlayer_LastSurvivor_Wins(t *testing.T) {
+	setup := newVictoryTestGame(t, 3, []bool{true, false, false})
+
+	_, err := setup.Game.EndTurn()
+	if err != nil {
+		t.Fatalf("EndTurn failed: %v", err)
+	}
+
+	if !setup.Game.GameState.Finished {
+		t.Errorf("expected Finished=true with only P1 alive; got false")
+	}
+	if got := setup.Game.GameState.WinningPlayer; got != 1 {
+		t.Errorf("expected WinningPlayer=1; got %d", got)
+	}
+}
+
+// TestVictoryConditions_MidTurnKill_NotEndedUntilEndTurn pins the
+// checked-only-on-EndTurn behavior. An attacker that eliminates the last
+// enemy unit mid-turn does NOT see Finished flip until they end the turn.
+// This is the deliberate single-check-point pattern in the current impl
+// rather than a bug — pinning it ensures any future move to mid-turn
+// victory detection is deliberate.
+func TestVictoryConditions_MidTurnKill_NotEndedUntilEndTurn(t *testing.T) {
+	setup := newVictoryTestGame(t, 2, []bool{true, true})
+
+	// Replace the default defender at (2,0) with a 1-HP soldier adjacent
+	// to a freshly-placed attacker so a single melee attack kills cleanly.
+	defender := setup.World.UnitAt(lib.AxialCoord{Q: 2, R: 0})
+	if defender == nil {
+		t.Fatal("defender not found at (2,0)")
+	}
+	setup.World.RemoveUnit(defender)
+	attacker := setup.World.UnitAt(lib.AxialCoord{Q: -2, R: 0})
+	if attacker == nil {
+		t.Fatal("attacker not found at (-2,0)")
+	}
+	setup.World.RemoveUnit(attacker)
+	setup.World.AddUnit(&v1.Unit{
+		Q: 0, R: 0, Player: 1, UnitType: UnitTypeSoldier,
+		AvailableHealth: 10, DistanceLeft: 3,
+	})
+	setup.World.AddUnit(&v1.Unit{
+		Q: 1, R: 0, Player: 2, UnitType: UnitTypeSoldier,
+		AvailableHealth: 1, DistanceLeft: 3,
+	})
+
+	move := &v1.GameMove{
+		MoveType: &v1.GameMove_AttackUnit{
+			AttackUnit: &v1.AttackUnitAction{
+				Attacker: &v1.Position{Q: 0, R: 0},
+				Defender: &v1.Position{Q: 1, R: 0},
+			},
+		},
+	}
+	if err := setup.Game.ProcessMove(move); err != nil {
+		t.Fatalf("ProcessMove (attack) failed: %v", err)
+	}
+
+	if setup.Game.GameState.Finished {
+		t.Errorf("expected Finished=false mid-turn (victory checked only on EndTurn); got true")
+	}
+	if got := setup.Game.GameState.WinningPlayer; got != 0 {
+		t.Errorf("expected WinningPlayer=0 mid-turn; got %d", got)
+	}
+
+	// Confirm the deferred check still fires correctly on EndTurn.
+	if _, err := setup.Game.EndTurn(); err != nil {
+		t.Fatalf("EndTurn after mid-turn kill failed: %v", err)
+	}
+	if !setup.Game.GameState.Finished {
+		t.Errorf("expected Finished=true after EndTurn following mid-turn kill; got false")
+	}
+}
+
+// TestVictoryConditions_MutualDestruction_NoWinner_BUG documents the
+// current behavior when every player simultaneously runs out of units
+// (e.g. mutual splash kill): checkVictoryConditions returns
+// hasWinner=false because the "last player with units" check requires
+// exactly one player to have units. The game then has no winner and no
+// end state — a real bug, tracked at issue 157. Test stays skipped until
+// that issue picks a tiebreaker rule.
+func TestVictoryConditions_MutualDestruction_NoWinner_BUG(t *testing.T) {
+	t.Skip("filed as issue 157 — mutual-destruction case needs tiebreaker decision before this can assert the right outcome")
+
+	setup := newVictoryTestGame(t, 2, []bool{false, false})
+
+	_, err := setup.Game.EndTurn()
+	if err != nil {
+		t.Fatalf("EndTurn failed: %v", err)
+	}
+
+	// Whatever rule issue 157 picks (draw / last-attacker / etc.), the
+	// game must reach a terminal state. The current impl does not, so this
+	// assertion will fail once unskipped — by design, pinning the fix.
+	if !setup.Game.GameState.Finished {
+		t.Errorf("expected Finished=true with mutual destruction; got false (game stuck)")
+	}
+}


### PR DESCRIPTION
Closes issue 120 (audit P0 item 5). Builds on PR 161 (which landed the helper + the no-premature-win pin) by adding the remaining victory-condition tests in a single follow-up.

## What changes

Four passing tests plus one documented-bug skip in `tests/victory_conditions_test.go`:

| Test | Pins |
|---|---|
| `TwoPlayer_LastStanding` | Baseline win — P2 has no units, EndTurn → P1 wins, Status flips to ENDED |
| `ThreePlayer_MidGameElim_NoWinner` | (a) 2 of 3 alive → no winner; (b) eliminated players keep their turn slot (CurrentPlayer 1 → 2 even though P2 has nothing to act with) |
| `ThreePlayer_LastSurvivor_Wins` | Multi-player convergence — only P1 retains units, EndTurn → P1 wins |
| `MidTurnKill_NotEndedUntilEndTurn` | Checked-only-on-EndTurn pattern — kill mid-turn doesn't flip Finished; EndTurn afterwards does |
| `MutualDestruction_NoWinner_BUG` (skipped) | Documents the real bug where zero-units-anywhere stuck state. Skipped pending tiebreaker decision at issue 157. |

## Reviewer's guide

1. [tests/victory_conditions_test.go](https://github.com/turnforge/lilbattle/pull/162/files#diff-4134611af2125bff0fb1e3cbe1873cdcdfc1a432fc445805ccade373e647f04e) — five new test functions appended after the one landed in PR 161. Pure append; no edits to the helper or the existing test.

## Decision log

- **Eliminated-player turn-slot behavior is *pinned*, not *fixed*.** The current cycling impl `CurrentPlayer = (CurrentPlayer % N) + 1` doesn't skip players with zero units, so P1 → P2 → P3 → P1 even if P2 is out. That's the live behavior; pinning it here makes any future change deliberate rather than accidental. If "skip eliminated players" is desired, it lands separately.
- **Mid-turn deferral is *pinned*, not *fixed*.** `checkVictoryConditions` is called only from `ProcessEndTurn`. An attacker who eliminates the last enemy mid-turn doesn't see Finished flip until they press End Turn. That's the live UX. Same reasoning — pinning means a future mid-turn check would be deliberate.
- **Mutual destruction stays skipped.** Picking a tiebreaker rule (draw / last-attacker / current-player-wins) is a product call. Issue 157 tracks the decision; this PR keeps a placeholder test that will assert the right outcome once unskipped.

## Risk / blast radius

- Tests-only PR. No production code touched.
- All passing tests pass on current main — they pin behavior, not fix it.

## Out of scope (filed as follow-ups)

| Audit gap | Issue |
|---|---|
| "Capture all bases" missing from victory check | 156 |
| Mutual-destruction tiebreaker decision | 157 |
| Wound bonus geometry verification (5 sub-cases) | 158 |
| Capture eligibility data (Soldier + Hovercraft only) | 159 |
| HealingBonus populated for all (unit, terrain) pairs | 160 |

