### PR TITLE
Dev-mode fake login via ?dev_user= query param

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -124,6 +124,42 @@ Builds for frontend, WASM, and backend run continuously. Do NOT manually run:
 - `npm run build` (web module auto-builds)
 - `buf generate` (protos auto-regenerate)
 
+### Dev-mode fake login (`?dev_user=`)
+
+For multi-client testing without registering N real accounts, the server
+supports a fake-login query parameter — opt-in via env var. Disabled by
+default; the middleware isn't even installed unless the gate is on.
+
+```bash
+# Start the dev server with the gate on
+ENABLE_DEV_FAKE_LOGIN=true devloop
+```
+
+Then open multiple browser windows, each pointing at the same game with
+a different identity:
+
+```
+http://localhost:8080/?dev_user=alice
+http://localhost:8080/?dev_user=bob
+```
+
+Each window now acts as a different logged-in user. The middleware writes
+the standard session/cookie/JWT triple via `oneauth.SetLoggedInSubject`,
+so every downstream auth check (page handlers, gRPC auth, sync) sees the
+identity exactly as it would after a real login. Subject sticks via cookie
+until you swap with `?dev_user=<other>` or clear cookies.
+
+The handle goes through verbatim as the session subject — meaning a game
+created with players `UserId="alice"` and `UserId="bob"` pairs naturally
+with two windows opened as those handles.
+
+> **Never enable `ENABLE_DEV_FAKE_LOGIN=true` in production.** The server
+> logs a startup banner and a per-event `slog.Warn` line on every
+> fake-login request so an accidental prod enablement is impossible to
+> miss in logs. The middleware itself is only added to the handler chain
+> when the env var is set at server boot — production handlers never
+> hold a reference to it.
+
 ## Testing
 
 ```bash

--- a/web/server/dev_login.go
+++ b/web/server/dev_login.go
@@ -1,0 +1,70 @@
+//go:build !wasm
+// +build !wasm
+
+package server
+
+import (
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/panyam/oneauth/httpauth"
+)
+
+const (
+	// DevLoginParam is the query parameter the middleware inspects when the
+	// gate is on. Visiting any URL with this param sets the session subject
+	// to the param's value, with no password or OAuth round-trip.
+	DevLoginParam = "dev_user"
+
+	// DevLoginEnvVar is the env var that gates the middleware. Anything
+	// other than "true" disables fake login entirely — the middleware
+	// short-circuits on the env check and passes the request through
+	// unchanged. Default state is OFF; production deploys must keep it
+	// that way.
+	DevLoginEnvVar = "ENABLE_DEV_FAKE_LOGIN"
+)
+
+// DevLoginEnabled reports whether the gate env var is currently set to
+// "true". Read at request time, not at startup, so changing the env in dev
+// (e.g. via `make devloop ENABLE_DEV_FAKE_LOGIN=true`) takes effect on the
+// next request without restarting tests.
+func DevLoginEnabled() bool {
+	return os.Getenv(DevLoginEnvVar) == "true"
+}
+
+// WrapDevLogin returns a middleware that intercepts ?dev_user=<handle> on
+// any path and calls oneauth.SetLoggedInSubject with that handle. The
+// handle becomes the session subject, the loggedInSubject cookie value,
+// and the JWT cookie's `sub` claim — identical to what a real login would
+// produce, just without the password / OAuth round-trip.
+//
+// Callers decide whether to install this middleware based on
+// DevLoginEnabled() at handler-build time, so production handlers never
+// even hold a reference to it. Wire it via:
+//
+//	withDevLogin := routes
+//	if server.DevLoginEnabled() { withDevLogin = WrapDevLogin(oneauth)(routes) }
+//	Session.LoadAndSave(withDevLogin)
+//
+// The middleware MUST run inside Session.LoadAndSave so the session writes
+// performed by SetLoggedInSubject reach the SCS store.
+//
+// Every fake-login event emits an slog.Warn line so a production deploy
+// that somehow installed this middleware cannot go unnoticed during log
+// review.
+func WrapDevLogin(oneauth *httpauth.OneAuth) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if handle := r.URL.Query().Get(DevLoginParam); handle != "" {
+				slog.Warn("dev-mode fake login (NEVER ENABLE IN PROD)",
+					"subject", handle,
+					"path", r.URL.Path,
+					"remote", r.RemoteAddr,
+					"env_var", DevLoginEnvVar)
+				oneauth.SetLoggedInSubject(handle, w, r)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/web/server/dev_login_test.go
+++ b/web/server/dev_login_test.go
@@ -1,0 +1,169 @@
+//go:build !wasm
+// +build !wasm
+
+package server
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/panyam/oneauth/httpauth"
+)
+
+// newDevLoginTestServer builds the smallest server that exercises
+// WrapDevLogin end-to-end: an scs session, an oneauth.OneAuth with the
+// session wired in (so SetLoggedInSubject can persist), the dev-login
+// middleware wrapping a tiny handler that reports the current subject.
+// Cookies set by SetLoggedInSubject propagate back via the standard
+// httptest.NewServer + http.Client jar pattern.
+func newDevLoginTestServer(t *testing.T) (*httptest.Server, *scs.SessionManager, *httpauth.OneAuth) {
+	t.Helper()
+
+	session := scs.New()
+	oneauth := httpauth.New("test")
+	oneauth.Session = session
+	oneauth.Middleware.SessionGetter = func(r *http.Request, key string) any {
+		return session.GetString(r.Context(), key)
+	}
+
+	// The inner handler echoes the current subject so tests can confirm
+	// whether the request was authenticated by the middleware.
+	echo := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		subj := oneauth.Middleware.GetLoggedInSubject(r)
+		w.Header().Set("X-Test-Subject", subj)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := WrapDevLogin(oneauth)(echo)
+	srv := httptest.NewServer(session.LoadAndSave(wrapped))
+	t.Cleanup(srv.Close)
+	return srv, session, oneauth
+}
+
+func newCookieClient(t *testing.T) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	return &http.Client{Jar: jar}
+}
+
+// TestDevLoginEnabled_RespectsEnvVar pins the gate's read-time semantics:
+// the function reflects whatever the env var is set to right now, so
+// callers can toggle the gate per-test via t.Setenv without restarting.
+func TestDevLoginEnabled_RespectsEnvVar(t *testing.T) {
+	t.Setenv(DevLoginEnvVar, "true")
+	if !DevLoginEnabled() {
+		t.Errorf("expected DevLoginEnabled()=true with env var set; got false")
+	}
+	t.Setenv(DevLoginEnvVar, "false")
+	if DevLoginEnabled() {
+		t.Errorf("expected DevLoginEnabled()=false when env var is not exactly 'true'; got true")
+	}
+	t.Setenv(DevLoginEnvVar, "")
+	if DevLoginEnabled() {
+		t.Errorf("expected DevLoginEnabled()=false when env var is unset; got true")
+	}
+}
+
+// TestWrapDevLogin_NoParam pins the no-op path: when the request carries no
+// ?dev_user=, the wrapper must pass through without touching the session.
+func TestWrapDevLogin_NoParam(t *testing.T) {
+	srv, _, _ := newDevLoginTestServer(t)
+	client := newCookieClient(t)
+
+	resp, err := client.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := resp.Header.Get("X-Test-Subject"); got != "" {
+		t.Errorf("expected empty subject without ?dev_user=; got %q", got)
+	}
+	if hasLoggedInCookie(resp.Cookies()) {
+		t.Errorf("expected no loggedInSubject cookie when no ?dev_user= sent")
+	}
+}
+
+// TestWrapDevLogin_WithParam pins the fake-login path: the handle in
+// ?dev_user= becomes the session subject and a loggedInSubject cookie is
+// set on the response.
+func TestWrapDevLogin_WithParam(t *testing.T) {
+	srv, _, _ := newDevLoginTestServer(t)
+	client := newCookieClient(t)
+
+	resp, err := client.Get(srv.URL + "/?dev_user=alice")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := resp.Header.Get("X-Test-Subject"); got != "alice" {
+		t.Errorf("expected subject=alice on the fake-login request itself; got %q", got)
+	}
+	if !hasLoggedInCookie(resp.Cookies()) {
+		t.Errorf("expected loggedInSubject cookie on the response; got %v", resp.Cookies())
+	}
+}
+
+// TestWrapDevLogin_SubjectPersistsAcrossRequests pins the durable-session
+// property — a second request to a URL *without* the param still sees the
+// subject set by the first, via the cookie. This is the multi-window
+// workflow the issue calls out: visit once with ?dev_user=alice, then
+// navigate freely as alice.
+func TestWrapDevLogin_SubjectPersistsAcrossRequests(t *testing.T) {
+	srv, _, _ := newDevLoginTestServer(t)
+	client := newCookieClient(t)
+
+	// First request sets the subject.
+	resp1, err := client.Get(srv.URL + "/?dev_user=alice")
+	if err != nil {
+		t.Fatalf("GET 1: %v", err)
+	}
+	resp1.Body.Close()
+
+	// Second request, no param — cookie alone must keep the subject.
+	resp2, err := client.Get(srv.URL + "/some/other/path")
+	if err != nil {
+		t.Fatalf("GET 2: %v", err)
+	}
+	resp2.Body.Close()
+
+	if got := resp2.Header.Get("X-Test-Subject"); got != "alice" {
+		t.Errorf("expected subject=alice on the no-param follow-up request; got %q", got)
+	}
+}
+
+// TestWrapDevLogin_SwapSubject pins the swap workflow — visiting with a
+// new ?dev_user= value replaces the previous identity in the session.
+func TestWrapDevLogin_SwapSubject(t *testing.T) {
+	srv, _, _ := newDevLoginTestServer(t)
+	client := newCookieClient(t)
+
+	resp1, _ := client.Get(srv.URL + "/?dev_user=alice")
+	resp1.Body.Close()
+
+	resp2, err := client.Get(srv.URL + "/?dev_user=bob")
+	if err != nil {
+		t.Fatalf("GET swap: %v", err)
+	}
+	resp2.Body.Close()
+
+	if got := resp2.Header.Get("X-Test-Subject"); got != "bob" {
+		t.Errorf("expected subject=bob after swap; got %q", got)
+	}
+}
+
+func hasLoggedInCookie(cookies []*http.Cookie) bool {
+	for _, c := range cookies {
+		if c.Name == "loggedInSubject" && c.Value != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/web/server/webapp.go
+++ b/web/server/webapp.go
@@ -173,7 +173,17 @@ func (a *LilBattleApp) Handler() http.Handler {
 		a.ViewsRoot.Handler().ServeHTTP(w, r)
 	}))
 
-	sessionHandler := a.Session.LoadAndSave(r)
+	// Dev-mode fake login (?dev_user=<handle>) — only installed when
+	// ENABLE_DEV_FAKE_LOGIN=true. Production handlers don't even hold a
+	// reference to the wrapper. The wrapper must run inside
+	// Session.LoadAndSave so the session writes performed by
+	// oneauth.SetLoggedInSubject reach the SCS store. See dev_login.go.
+	var inner http.Handler = r
+	if DevLoginEnabled() {
+		log.Println("WARNING: ENABLE_DEV_FAKE_LOGIN=true — ?dev_user=<handle> can impersonate any subject. NEVER enable in production.")
+		inner = WrapDevLogin(a.Auth)(r)
+	}
+	sessionHandler := a.Session.LoadAndSave(inner)
 
 	// Wrap with security headers (outermost middleware)
 	return securityHeaders.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Closes issue 166.

## What changes

Adds a session-level fake-login affordance for dev mode: any URL with `?dev_user=<handle>` sets the session subject to that handle via the canonical `oneauth.SetLoggedInSubject` path. Gated behind `ENABLE_DEV_FAKE_LOGIN=true`; the middleware is only installed in the handler chain when the gate is on, so production handlers never hold a reference to it.

Unblocks issue 165 (N-client multiplayer launcher) and issue 167 Stage 2 (web autoplay driver) — both need a way to drive multiple identities from one dev machine without account juggling or header injection.

## Reviewer's guide

Read in this order:

1. [web/server/dev_login.go](https://github.com/turnforge/lilbattle/pull/171/files#diff-7c3d0336f50159f29fcb053d7d1e1d4d12ba07edca7b433c65e2d3296bdf68b5) — middleware + env-var gate. The whole feature in 65 lines.
2. [web/server/webapp.go](https://github.com/turnforge/lilbattle/pull/171/files#diff-110d1aa4c4845ecf1732311d597fb8233088384c4153b644137f94c26713222e) — three-line wiring change inside `Handler()`. The if-statement is the safety story: if `ENABLE_DEV_FAKE_LOGIN != "true"` at boot, the wrapper isn't even constructed.
3. [web/server/dev_login_test.go](https://github.com/turnforge/lilbattle/pull/171/files#diff-8e3ef39b6fed583575f31297bcb4915683ac6e38c80509929ddf06e37b1f983d) — 5 tests using `httptest` + stdlib `cookiejar`. Start with `TestWrapDevLogin_WithParam` for the happy path, then `TestWrapDevLogin_SubjectPersistsAcrossRequests` for the cookie semantics.
4. [docs/DEVELOPER_GUIDE.md](https://github.com/turnforge/lilbattle/pull/171/files#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092) — new "Dev-mode fake login" subsection with usage + safety note.

## Decision log

- **New env var, not reusing `ENABLE_TEST_AUTH`.** That existing flag controls a user-store swap (returns hardcoded `testUser` for `userId=="test1"`), conceptually different from "let any handle through as a session subject." Overloading would force readers of either feature to understand both.

- **Middleware over a `/auth/devlogin?as=X` redirect endpoint.** Issue body explicitly says "visiting that URL in any browser tab" — the multi-window workflow needs the original URL the user wanted to visit, not a separate login page.

- **Gate decision at handler-build time, not per-request.** Per review feedback during implementation: rather than the wrapper checking the env var on every request, the wiring code checks once at boot and only inserts the wrapper if true. Production servers don't even hold a reference to the wrapper.

- **Subject = handle verbatim, no oneauth-store lookup.** Simpler and covers the use case (drive a fresh game with `UserId="alice"`). A real-userId lookup would add cross-store logic for marginal gain — anyone with a real `alice` user in their dev store is going to be impersonating that user anyway, by design.

- **Full SetLoggedInSubject (session + cookie + JWT), not just session.** Tempting to write only the session value for "lighter dev login," but then any code path that checks the cookie or JWT (e.g., the API bearer flow) wouldn't see the fake login. Using the canonical method makes the fake login indistinguishable from real login in every downstream check.

## Risk / blast radius

- **Default behavior unchanged.** Flag off → wrapper not constructed, not installed, not called.
- **Bad case = subject of attacker's choice.** Only triggers if someone enables the gate in prod AND lets an attacker reach the server. The startup banner + per-event warning log are the safety net.
- **No interaction with existing auth paths.** Real OAuth, local login, and the API auth interceptor are untouched.

## Before / after

After merge, this works in dev:

```bash
ENABLE_DEV_FAKE_LOGIN=true devloop
# Browser tab A: http://localhost:8080/?dev_user=alice
# Browser tab B: http://localhost:8080/?dev_user=bob
# Each tab acts as the respective user for every downstream request.
```

Without the env var, the same URL is treated as if `?dev_user=` weren't there.

## Out of scope (filed elsewhere)

- The N-client launcher script that uses this → issue 165
- Autoplay web driver → issue 167 Stage 2
- Consolidating `ENABLE_TEST_AUTH` + `ENABLE_SWITCH_AUTH` + `ENABLE_DEV_FAKE_LOGIN` under a single dev-mode umbrella — bigger refactor; could be a separate cleanup if any of these flags multiply further.

