### PR TITLE
Surface DamageEstimate in TurnOptionsPanel attack buttons

### DIFF
--- a/web/templates/TurnOptionsPanel.templar.html
+++ b/web/templates/TurnOptionsPanel.templar.html
@@ -74,7 +74,7 @@
             </div>
             <div class="text-xs text-gray-500 dark:text-gray-400">
               Target: {{ $theme.GetUnitName $attack.TargetUnitType }} (HP: {{
-              $attack.TargetUnitHealth }})
+              $attack.TargetUnitHealth }}) · Est. damage: {{ $attack.DamageEstimate }}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes issue 163.

## What changes

PR 155 replaced the hardcoded `damageEstimate := int32(50) // TODO` with a real per-pairing analytical estimate (`RulesEngine.EstimateCombatDamage`). The CLI started showing real numbers immediately (`ww options <unit>` reads `AttackUnitAction.DamageEstimate`), but no web template was consuming the field — web users have continued to see *nothing*, while CLI users saw the corrected number.

This PR finally puts PR 155's payoff in front of web users. One line of templar in the attack-option button: appends `· Est. damage: <N>` to the existing Target line.

```
⚔️ Attack at (q, r)
   Target: Tank (HP: 10) · Est. damage: 5
```

Propagates to every web entry point (grid view, mobile, DockView) through the shared `BrowserTurnOptionsPanel.SetCurrentUnit` renderer at `cmd/wasm/browser.go:35`.

## Reviewer's guide

1. [web/templates/TurnOptionsPanel.templar.html](https://github.com/turnforge/lilbattle/pull/172/files#diff-59e94806f28cc9bfe70371b5a01f0c825b53ba281ec17e3dd4dc1d1795c5f0b8) — one-line addition in the `{{ else if $attack }}` branch's target line. That's the entire PR.

## Decision log

- **Inline append, not a new sub-line.** Matches the build-option formatting precedent in the same file (`{{ $theme.GetUnitName $build.UnitType }} - {{ $build.Cost }} coins`). Keeps button height constant; the attack-option list can have many entries.
- **Always show, even when `DamageEstimate == 0`.** A genuine zero is meaningful info ("you can't hurt this with current matchup"), not a missing-data sentinel.
- **No automated template render test.** The proto field's correctness is already pinned by PR 155's tests (`TestEstimateCombatDamage_Analytical` + `TestEstimateCombatDamage_MatchesSimulationMean` in `tests/combat_formula_test.go`). A render test for "does this templar accessor read a populated proto field" exercises the template engine, not lilbattle. Per discipline rule: tests pin behavior, not decorate it.

## Risk / blast radius

- **Tiny.** One line of templar. Renders cleanly even if the field is somehow zero (`· Est. damage: 0`).
- **Affects every web user immediately on merge.** PR 155's payoff finally reaches them.
- **CLI users unchanged** — same proto field, same data, just rendered in a second surface now.

## Before / after

**Before merge** — web attack-option button shows:
```
⚔️ Attack at (1, 0)
   Target: Tank (HP: 10)
```

**After merge:**
```
⚔️ Attack at (1, 0)
   Target: Tank (HP: 10) · Est. damage: 5
```

The "5" matches `ww options <attacker>` for the same scenario, because both pull from `AttackUnitAction.DamageEstimate` populated by the rules engine.

## Out of scope (potential follow-ups)

- Delete the stale 177-line `web/templates/TurnOptionsPanel.html` — dead code, not loaded by `cmd/wasm/browser.go`. Cleanup belongs in its own change.
- Phaser hover tooltip with full damage distribution — `DamageDistributionPanel.templar.html` already covers that surface.
- Animate the estimate when state changes — not in scope.

