### PR TITLE
Browser moves persist via server (closes 174)

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -156,6 +156,22 @@ func main() {
 		}
 	}))
 
+	// registerMovePersister lets JavaScript inject the callback the WASM-side
+	// SingletonGamesService delegates SaveMoveGroup to. Called once by the
+	// FE right after loadGameData; without this, moves stay in the WASM
+	// heap and are lost on refresh (the pre-issue-174 bug).
+	fmt.Println("Adding registerMovePersister function to existing lilbattle object")
+	lilbattleObj.Set("registerMovePersister", js.FuncOf(func(this js.Value, args []js.Value) any {
+		if len(args) != 1 || args[0].Type() != js.TypeFunction {
+			return map[string]any{
+				"success": false,
+				"error":   "registerMovePersister requires a single function argument",
+			}
+		}
+		wasmGamesService.Persister = &jsCallbackPersister{callback: args[0]}
+		return map[string]any{"success": true}
+	}))
+
 	fmt.Println("LilBattle WASM module loaded successfully")
 
 	// Keep the WASM module running

--- a/cmd/wasm/move_persister.go
+++ b/cmd/wasm/move_persister.go
@@ -1,0 +1,86 @@
+//go:build js && wasm
+// +build js,wasm
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"syscall/js"
+
+	v1 "github.com/turnforge/lilbattle/gen/go/lilbattle/v1/models"
+	pj "google.golang.org/protobuf/encoding/protojson"
+)
+
+// jsCallbackPersister bridges Go's singleton.MovePersister interface to a
+// JavaScript async function registered via lilbattle.registerMovePersister.
+//
+// The Save call marshals state + group to protojson (readable in devtools;
+// size penalty is trivial for a single group per user action), invokes the
+// JS callback with (gameId, stateJSON, groupJSON), and awaits the returned
+// Promise. Any Promise rejection surfaces as a Go error so
+// BaseGamesService.ProcessMoves can propagate it and the FE can log or
+// react.
+type jsCallbackPersister struct {
+	callback js.Value // JS function: (gameId, stateJSON, groupJSON) -> Promise<void>
+}
+
+// Save marshals the arguments and awaits the JS callback's Promise. A
+// non-resolvable callback (missing, wrong type, throws synchronously)
+// produces a descriptive error; the FE surfaces persistence failures
+// via the game-log panel.
+func (p *jsCallbackPersister) Save(ctx context.Context, gameID string, state *v1.GameState, group *v1.GameMoveGroup) error {
+	if !p.callback.Truthy() {
+		return fmt.Errorf("no move persister registered from JS")
+	}
+
+	stateJSON, err := pj.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
+	}
+	groupJSON, err := pj.Marshal(group)
+	if err != nil {
+		return fmt.Errorf("marshal group: %w", err)
+	}
+
+	promise := p.callback.Invoke(gameID, string(stateJSON), string(groupJSON))
+	return awaitPromise(promise)
+}
+
+// awaitPromise blocks until the JS Promise settles and returns a Go error
+// if it rejected. Uses Then/Catch to bridge the JS event loop back to the
+// Go goroutine via a done channel — this is the standard syscall/js pattern
+// for turning a Promise into synchronous Go control flow.
+func awaitPromise(promise js.Value) error {
+	if !promise.Truthy() {
+		return nil
+	}
+	if then := promise.Get("then"); !then.Truthy() {
+		return nil
+	}
+
+	done := make(chan error, 1)
+
+	onResolve := js.FuncOf(func(this js.Value, args []js.Value) any {
+		done <- nil
+		return nil
+	})
+	defer onResolve.Release()
+
+	onReject := js.FuncOf(func(this js.Value, args []js.Value) any {
+		msg := "js persister rejected"
+		if len(args) > 0 {
+			if s := args[0].Get("message"); s.Truthy() {
+				msg = s.String()
+			} else {
+				msg = args[0].String()
+			}
+		}
+		done <- fmt.Errorf("%s", msg)
+		return nil
+	})
+	defer onReject.Release()
+
+	promise.Call("then", onResolve).Call("catch", onReject)
+	return <-done
+}

--- a/services/singleton/games_service.go
+++ b/services/singleton/games_service.go
@@ -16,6 +16,11 @@ type SingletonGamesService struct {
 	SingletonGameMoveHistory *v1.GameMoveHistory
 
 	RuntimeGame *lib.Game
+
+	// Persister receives every SaveMoveGroup call. Defaults to NoopPersister
+	// (in-memory only, matches pre-issue-174 behavior). Browser wires a
+	// jsCallbackPersister at WASM init; tests wire a recorder.
+	Persister MovePersister
 }
 
 // NOTE - ONly API really needed here are "getters" and "move processors" so no Creations, Deletions, Listing or even
@@ -28,6 +33,7 @@ func NewSingletonGamesService() *SingletonGamesService {
 		SingletonGame:            &v1.Game{},
 		SingletonGameState:       &v1.GameState{},
 		SingletonGameMoveHistory: &v1.GameMoveHistory{},
+		Persister:                NoopPersister{},
 	}
 	w.Self = w
 	return w
@@ -38,8 +44,12 @@ func (w *SingletonGamesService) WorldData() *v1.WorldData {
 }
 
 func (w *SingletonGamesService) SaveMoveGroup(ctx context.Context, gameId string, state *v1.GameState, group *v1.GameMoveGroup) error {
-	// NOOP - Will have to do local first coordination etc
-	return nil
+	// Delegate to the wired persister. Default NoopPersister keeps the
+	// in-memory-only behavior tests and non-browser callers rely on; browser
+	// installs a jsCallbackPersister at WASM init that POSTs back to
+	// /api/lilbattle.v1.GamesService/ProcessMoves and returns the server's
+	// error verbatim (auth rejection propagates so the FE can surface it).
+	return w.Persister.Save(ctx, gameId, state, group)
 }
 
 func (w *SingletonGamesService) GetRuntimeGame(game *v1.Game, gameState *v1.GameState) (out *lib.Game, err error) {

--- a/services/singleton/move_persister.go
+++ b/services/singleton/move_persister.go
@@ -1,0 +1,34 @@
+package singleton
+
+import (
+	"context"
+
+	v1 "github.com/turnforge/lilbattle/gen/go/lilbattle/v1/models"
+)
+
+// MovePersister is the hook SingletonGamesService.SaveMoveGroup delegates to
+// when the singleton needs to write moves durably. The singleton itself only
+// holds an in-memory copy of the game — persistence is out-of-band and
+// pluggable so browser (WASM) code can push writes back to the server, tests
+// can capture the moves, and future 1P / vs-AI modes can persist to
+// IndexedDB or a local-first mesh without changing the game logic.
+//
+// Implementations must be safe to call from any goroutine.
+type MovePersister interface {
+	// Save persists a completed move group and the resulting game state.
+	// Called from BaseGamesService.ProcessMoves after the moves have been
+	// applied to the in-memory runtime. A non-nil error surfaces to the
+	// caller of ProcessMoves; the FE decides whether to log, roll back, or
+	// reload from canonical state.
+	Save(ctx context.Context, gameId string, state *v1.GameState, group *v1.GameMoveGroup) error
+}
+
+// NoopPersister discards every Save call. This is SingletonGamesService's
+// default so autoplay smoke tests and any non-browser caller that doesn't
+// wire a persister keep today's in-memory-only behavior.
+type NoopPersister struct{}
+
+// Save always returns nil.
+func (NoopPersister) Save(context.Context, string, *v1.GameState, *v1.GameMoveGroup) error {
+	return nil
+}

--- a/services/singleton/move_persister_test.go
+++ b/services/singleton/move_persister_test.go
@@ -1,0 +1,92 @@
+//go:build !wasm
+// +build !wasm
+
+package singleton
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	v1 "github.com/turnforge/lilbattle/gen/go/lilbattle/v1/models"
+)
+
+// recordingPersister captures the args of the last Save call and can be
+// configured to return a specific error. Used to prove SaveMoveGroup wires
+// the args through verbatim and propagates errors.
+type recordingPersister struct {
+	saved     int
+	gotGameID string
+	gotState  *v1.GameState
+	gotGroup  *v1.GameMoveGroup
+	err       error
+}
+
+func (r *recordingPersister) Save(_ context.Context, gameID string, state *v1.GameState, group *v1.GameMoveGroup) error {
+	r.saved++
+	r.gotGameID = gameID
+	r.gotState = state
+	r.gotGroup = group
+	return r.err
+}
+
+// TestSaveMoveGroup_DelegatesToPersister pins the contract the browser JS
+// bridge and any future persister impl rely on: SaveMoveGroup forwards
+// (gameId, state, group) verbatim to the injected Persister and returns its
+// error. Regression here would silently drop browser writes or swallow
+// server auth errors.
+func TestSaveMoveGroup_DelegatesToPersister(t *testing.T) {
+	svc := NewSingletonGamesService()
+	rec := &recordingPersister{}
+	svc.Persister = rec
+
+	state := &v1.GameState{TurnCounter: 7}
+	group := &v1.GameMoveGroup{GroupNumber: 3}
+	err := svc.SaveMoveGroup(context.Background(), "game-abc", state, group)
+
+	if err != nil {
+		t.Fatalf("SaveMoveGroup returned unexpected error: %v", err)
+	}
+	if rec.saved != 1 {
+		t.Errorf("persister.saved = %d, want 1", rec.saved)
+	}
+	if rec.gotGameID != "game-abc" {
+		t.Errorf("gameId = %q, want %q", rec.gotGameID, "game-abc")
+	}
+	if rec.gotState != state {
+		t.Errorf("state pointer mismatch (persister must receive the caller's pointer verbatim)")
+	}
+	if rec.gotGroup != group {
+		t.Errorf("group pointer mismatch (persister must receive the caller's pointer verbatim)")
+	}
+}
+
+// TestSaveMoveGroup_PropagatesPersisterError pins the error path: server
+// auth rejection (401 becomes non-nil error at the JS bridge) must reach the
+// caller of SaveMoveGroup so BaseGamesService.ProcessMoves can bubble it up
+// and the FE can log / react.
+func TestSaveMoveGroup_PropagatesPersisterError(t *testing.T) {
+	svc := NewSingletonGamesService()
+	sentinel := errors.New("simulated 401 unauthorized")
+	svc.Persister = &recordingPersister{err: sentinel}
+
+	err := svc.SaveMoveGroup(context.Background(), "game-x", &v1.GameState{}, &v1.GameMoveGroup{})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("SaveMoveGroup = %v, want %v", err, sentinel)
+	}
+}
+
+// TestSaveMoveGroup_DefaultNoopPreservesLegacyBehavior pins the
+// backward-compat contract for autoplay smoke tests and any non-browser
+// caller: a freshly-constructed SingletonGamesService (no persister set)
+// treats SaveMoveGroup as a no-op returning nil. Without the NoopPersister
+// default, calling SaveMoveGroup would nil-dereference svc.Persister and
+// break autoplay in a hard-to-diagnose way.
+func TestSaveMoveGroup_DefaultNoopPreservesLegacyBehavior(t *testing.T) {
+	svc := NewSingletonGamesService()
+
+	err := svc.SaveMoveGroup(context.Background(), "any", &v1.GameState{}, &v1.GameMoveGroup{})
+	if err != nil {
+		t.Errorf("default NoopPersister.Save returned %v, want nil", err)
+	}
+}

--- a/web/pages/GameViewerPage/GameViewerPageBase.ts
+++ b/web/pages/GameViewerPage/GameViewerPageBase.ts
@@ -33,6 +33,7 @@ import { TerrainStatsPanel } from './TerrainStatsPanel';
 import { UnitStatsPanel } from './UnitStatsPanel';
 import { DamageDistributionPanel } from './DamageDistributionPanel';
 import { GameLogPanel } from './GameLogPanel';
+import { ServerPersister } from './ServerPersister';
 import { TurnOptionsPanel } from './TurnOptionsPanel';
 import { BuildOptionsModal } from './BuildOptionsModal';
 import { GameEndedModal } from './GameEndedModal';
@@ -376,6 +377,35 @@ export abstract class GameViewerPageBase extends BasePage implements LCMComponen
         this.singletonInitializerClient = new SingletonInitializerClient(this.wasmBundle);
         await this.wasmBundle.loadWasm((document.getElementById("wasmBundlePathField") as HTMLInputElement).value);
         await this.wasmBundle.waitUntilReady();
+        this.registerMovePersister();
+    }
+
+    /**
+     * Wire the WASM SingletonGamesService's SaveMoveGroup to a ServerPersister
+     * that POSTs moves back to the server. Without this call, every
+     * browser-initiated move stays in the WASM heap and is lost on refresh
+     * (the pre-issue-174 bug). Persistence failures (401 anonymous,
+     * forbidden non-player, network errors) surface via the game-log panel.
+     */
+    private registerMovePersister(): void {
+        const lb = (window as any).lilbattle;
+        if (!lb || typeof lb.registerMovePersister !== 'function') {
+            throw new Error('lilbattle.registerMovePersister missing — WASM bridge out of date');
+        }
+        const persister = new ServerPersister();
+        lb.registerMovePersister(async (gameId: string, stateJson: string, groupJson: string) => {
+            try {
+                await persister.save(gameId, stateJson, groupJson);
+            } catch (err) {
+                // Surface to the game log so users see WHY their move
+                // didn't stick. Then rethrow so the WASM Go side turns it
+                // into a ProcessMoves error that BaseGamesService can
+                // propagate upstream.
+                const message = err instanceof Error ? err.message : String(err);
+                this.gameLogPanel?.logGameEvent(`Move not saved: ${message}`, 'system');
+                throw err;
+            }
+        });
     }
 
     /**

--- a/web/pages/GameViewerPage/ServerPersister.ts
+++ b/web/pages/GameViewerPage/ServerPersister.ts
@@ -1,0 +1,55 @@
+/**
+ * ServerPersister receives protojson-encoded move groups from the WASM-side
+ * SingletonGamesService (via the lilbattle.registerMovePersister JS bridge)
+ * and POSTs them back to the server's ProcessMoves Connect endpoint.
+ *
+ * Same-origin fetch with `credentials: 'include'` attaches the session
+ * cookie automatically. The server's auth middleware (oneauth) + the
+ * per-game player check (services/authz.CanSubmitMoves) fire on every call.
+ * An anonymous viewer's write gets rejected with 401; a logged-in
+ * non-player gets rejected with a forbidden-status error; the player who
+ * owns the current turn succeeds. Errors are thrown so the WASM Go side
+ * can propagate them; the FE surfaces them via the game-log panel.
+ *
+ * NOTE: The WASM side already applied moves to the in-memory state before
+ * SaveMoveGroup fires. A server rejection means the browser's optimistic
+ * state now diverges from the canonical server state. For issue 174 we
+ * accept the divergence and rely on page refresh to restore correctness
+ * (per the ticket's log-only acceptance criterion). Reconciliation is a
+ * separate follow-up.
+ */
+export class ServerPersister {
+    /**
+     * POST the (state, group) pair back to the server's ProcessMoves
+     * endpoint. Throws on non-2xx so the WASM bridge sees a Promise
+     * rejection and turns it into a Go error.
+     */
+    async save(gameId: string, stateJson: string, groupJson: string): Promise<void> {
+        // ProcessMoves takes moves in the request; the group carries the
+        // move list. Repack into the shape the server expects.
+        const group = JSON.parse(groupJson);
+        const body = JSON.stringify({
+            gameId,
+            moves: group.moves || [],
+        });
+
+        const url = '/api/lilbattle.v1.GamesService/ProcessMoves';
+        const resp = await fetch(url, {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body,
+        });
+
+        if (resp.ok) {
+            return;
+        }
+
+        // Non-2xx: read the body for whatever error text the Connect
+        // handler produced (typically a JSON envelope with `code` and
+        // `message`). Throw with a compact human-readable message.
+        const text = await resp.text().catch(() => '');
+        const suffix = text ? `: ${text.slice(0, 200)}` : '';
+        throw new Error(`ProcessMoves ${resp.status} ${resp.statusText}${suffix}`);
+    }
+}


### PR DESCRIPTION
## What changes

Fixes two bugs with one wiring change:

1. **Browser moves silently didn't persist.** `SingletonGamesService.SaveMoveGroup` was a NOOP. Every move lived in the WASM heap until the user refreshed and lost it.
2. **Anonymous users could freely play.** `services/authz/authz_wasm.go` stubs `RequireAuthenticated` to always succeed in the WASM context. Combined with the NOOP persister, no server round-trip fired, so the server-side authz check never ran.

Both collapse if the WASM `SingletonGamesService` pushes writes back to the server's `ProcessMoves` endpoint via cookie-auth'd fetch. Server's existing `authz.CanSubmitMoves` (`services/games_service.go:90`) fires on every call and rejects anonymous / non-player writes.

Closes issue 174.

## Sequence — happy path (logged-in player)

```mermaid
sequenceDiagram
    autonumber
    participant User
    participant PhaserScene as PhaserGameScene
    participant Base as GameViewerPageBase
    participant WASM as WASM Presenter
    participant Sing as SingletonGamesService
    participant Base_svc as BaseGamesService.ProcessMoves
    participant JSBridge as jsCallbackPersister (Go)
    participant JSCB as ServerPersister.save (TS)
    participant Fetch as browser fetch
    participant Conn as /api/.../ProcessMoves
    participant AuthMW as httpauth.Middleware
    participant Adapter as ConnectGamesServiceAdapter
    participant gRPC as grpc UnaryAuthInterceptor
    participant Backend as BackendGamesService
    participant FS as disk (state.json)

    User->>PhaserScene: click tile
    PhaserScene->>WASM: sceneClicked
    WASM->>Sing: ProcessMoves([move])
    Sing->>Base_svc: dispatch
    Base_svc->>Base_svc: authz.CanSubmitMoves (WASM stub: allow)
    Base_svc->>Base_svc: apply moves to in-memory game
    Base_svc->>Sing: SaveMoveGroup(state, group)
    Sing->>JSBridge: Persister.Save
    JSBridge->>JSBridge: protojson marshal state + group
    JSBridge->>JSCB: invoke JS callback (gameId, stateJSON, groupJSON)
    JSCB->>Fetch: POST /api/.../ProcessMoves (credentials: include)
    Fetch->>Conn: HTTP with session cookie
    Conn->>AuthMW: GetLoggedInSubject
    AuthMW-->>Conn: subject = "alice"
    Conn->>Adapter: ConnectGamesServiceAdapter.ProcessMoves
    Adapter->>Adapter: injectAuthMetadata (outgoing + incoming)
    Adapter->>gRPC: grpc call with subject metadata
    gRPC->>gRPC: RequireAuthenticated (real check) — pass
    gRPC->>Backend: BackendGamesService.ProcessMoves
    Backend->>Backend: authz.CanSubmitMoves (real check, per-game player) — pass
    Backend->>Backend: apply moves (canonical)
    Backend->>FS: write history + state.json
    FS-->>Backend: ok
    Backend-->>gRPC: 200
    gRPC-->>Adapter: response
    Adapter-->>Conn: response
    Conn-->>Fetch: 200 OK
    Fetch-->>JSCB: resolve
    JSCB-->>JSBridge: Promise resolves
    JSBridge-->>Sing: nil error
    Sing-->>Base_svc: nil error
    Base_svc-->>WASM: ProcessMovesResponse
    WASM-->>Base: UI update via RPCs
    Base-->>User: tile highlights, unit moves, log entry
```

## Sequence — anonymous viewer (rejection)

```mermaid
sequenceDiagram
    autonumber
    participant User as Anonymous viewer
    participant WASM as WASM Presenter
    participant Sing as SingletonGamesService
    participant Base_svc as BaseGamesService.ProcessMoves
    participant JSBridge as jsCallbackPersister
    participant JSCB as ServerPersister.save
    participant AuthMW as httpauth.Middleware
    participant gRPC as UnaryAuthInterceptor
    participant Backend as BackendGamesService

    User->>WASM: click End Turn
    WASM->>Sing: ProcessMoves([endTurn])
    Sing->>Base_svc: dispatch
    Base_svc->>Base_svc: WASM authz stub allows (local optimistic apply happens)
    Base_svc->>Sing: SaveMoveGroup
    Sing->>JSBridge: Persister.Save
    JSBridge->>JSCB: invoke callback
    JSCB->>AuthMW: POST /api/... (no cookie)
    AuthMW-->>AuthMW: GetLoggedInSubject returns ""
    AuthMW->>gRPC: forwards with empty subject
    gRPC-->>JSCB: 401 Unauthenticated
    JSCB-->>JSCB: throw Error("ProcessMoves 401 ...")
    JSCB-->>JSBridge: Promise rejects
    JSBridge-->>Sing: Go error
    Sing-->>Base_svc: error
    Base_svc-->>WASM: error surfaces to caller
    Note over WASM: Local in-memory state now<br/>diverges from canonical.<br/>Refresh restores correctness.
    JSCB->>User: GameLogPanel: "Move not saved: ProcessMoves 401 ..."
```

## Sequence — logged-in non-player (rejection)

```mermaid
sequenceDiagram
    autonumber
    participant User as Logged-in non-player
    participant JSCB as ServerPersister.save
    participant AuthMW as httpauth.Middleware
    participant Backend as BackendGamesService
    participant Authz as authz.CanSubmitMoves

    User->>JSCB: cookie'd POST /api/.../ProcessMoves
    JSCB->>AuthMW: request with session cookie
    AuthMW-->>JSCB: subject = "mallory"
    Note over AuthMW,Backend: interceptor + Connect adapter same as happy path
    Backend->>Authz: CanSubmitMoves(ctx, game, currentPlayer)
    Authz-->>Backend: ErrForbidden ("not a player in this game")
    Backend-->>JSCB: gRPC PermissionDenied / non-2xx
    JSCB-->>User: GameLogPanel: "Move not saved: ProcessMoves 403 ..."
```

## Reviewer's guide

Read in this order:

1. [services/singleton/move_persister.go](https://github.com/turnforge/lilbattle/pull/181/files#diff-6b289da0b8123d43ddd2f795a7378098cae102de9841e6c868cd42b2c667574e) — the interface + NoopPersister. Two types, one file. Start here for the shape.
2. [services/singleton/games_service.go](https://github.com/turnforge/lilbattle/pull/181/files#diff-c737da96f51a036c77f38a10bc7df72faabce91404f02a0626c4879abf8334b9) — Persister field + delegating SaveMoveGroup. Backward-compat via NoopPersister default.
3. [services/singleton/move_persister_test.go](https://github.com/turnforge/lilbattle/pull/181/files#diff-a9f0cfa55f4b7ff725387754e0a8ff17d5e90235ed604f2555a52d9c701250aa) — 3 tests pin the contract (delegation, error propagation, backward-compat).
4. [cmd/wasm/move_persister.go](https://github.com/turnforge/lilbattle/pull/181/files#diff-8965d56ca613502700c95af0e87432b1eea119e578207080f9355d49d7501f67) — `jsCallbackPersister` bridges Go to JS via protojson + Promise-await.
5. [cmd/wasm/main.go](https://github.com/turnforge/lilbattle/pull/181/files#diff-1a1e16bd11061b4892de841ee25801dd23676d371bc3c7619281801d9bdecdc0) — new `lilbattle.registerMovePersister` JS entrypoint.
6. [web/pages/GameViewerPage/ServerPersister.ts](https://github.com/turnforge/lilbattle/pull/181/files#diff-528285df292f3ec4a9b41aef512a2a1965e52a2c4b973bb54b58f9591a3a99b6) — fetch to `/api/.../ProcessMoves` with `credentials: 'include'`.
7. [web/pages/GameViewerPage/GameViewerPageBase.ts](https://github.com/turnforge/lilbattle/pull/181/files#diff-746af585d3ce6b5d9abdd0611cb4f0ebdb3d0eca8f5a7f8230f1e1b14b609e6d) — wires it all together right after WASM ready. Errors surface via `gameLogPanel.logGameEvent`.

## Decision log

- **Optimistic vs server-first.** Optimistic (local apply, then persist async) chosen for UI responsiveness — every tile click gets instant feedback. Server rejection diverges the in-memory state; the acceptance criterion in issue 174 (log-only on failure) tolerates this. Refresh restores correctness. Reconciliation is a follow-up if divergence becomes user-visible in practice.
- **protojson, not vtproto/binary, for the bridge payload.** Readable in devtools; size penalty is trivial for one move group per user action.
- **`credentials: 'include'` rather than manual cookie plumbing.** Same-origin fetch auto-attaches; no token handling on the FE.
- **Single registration callback, not a typed RPC handle.** The JS side needs one function reference; a typed RPC would drag in Connect codegen or another wrapper. The current shape is 20 lines of Go + one TS class.
- **Log-only error UX.** Per issue 174 acceptance ("silently no-op / log to game-log"). No modals, no state rollback in this PR.

## Risk / blast radius

- Every browser-initiated move now hits the server. New network traffic; expected because browser-first was silently dropping writes anyway.
- Server-side ProcessMoves is idempotent on `CurrentGroupNumber` — duplicate sends (retry, double-click) are safe.
- `NoopPersister` default preserves autoplay smoke tests and any non-WASM `SingletonGamesService` caller.
- WASM binary size: +~20KB for protojson + the bridge functions.

## Tests

- `services/singleton/move_persister_test.go` (new) — 3 unit tests, all pass.
- Existing autoplay smoke (`tests/autoplay_smoke_test.go`) — unaffected by NoopPersister default, all pass.
- Existing CLI auth integration (`web/server/cli_auth_integration_test.go` from PR 179) — the server-side auth path this PR exercises is already pinned there.
- Pre-push hook — green (Go build + tests + WASM build + jest).

Manual smoke to run before merge:
1. Anonymous viewer at `/games/<id>/view`, click End Turn → game-log shows "Move not saved: ProcessMoves 401 …", `state.json` unchanged.
2. Logged-in player (`?dev_user=<owner>`), make a move → `jq .turn_counter state.json` increments.
3. Logged-in non-player (`?dev_user=mallory` on a game where alice + bob are players), attempt move → game-log shows forbidden rejection, `state.json` unchanged.

## Out of scope

- IndexedDB persister (1P / vs-AI games where no server round-trip is wanted).
- Orchestrator persister (local-first sync mesh).
- Rollback / canonical-state reconciliation on server reject.
- Sync convergence regressions (existing MovesPublished broadcast path is untouched).
